### PR TITLE
Added maven assembly plugin in pom.xml to generate a fat jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,25 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <version>3.1.1</version>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Added maven assembly plugin in pom.xml to generate a fat jar with all dependencies. This fat jar will be used in Casper Integrations to ease the integration example execution.