### PR TITLE
NO_TICKET: remove other maven url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ targetCompatibility = 1.8
 repositories {
     mavenCentral()
     maven { url 'https://s01.oss.sonatype.org/content/repositories/snapshots' }
-    maven { url 'https://repo1.maven.org/maven2' }
 }
 
 


### PR DESCRIPTION
Removes a "suspected" issue causing url from build.gradle