### PR TITLE
fix naming typo

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,7 @@ publishing {
 
     publications {
         mavenJava(MavenPublication) {
-            artifactId = 'casper-sdk'
+            artifactId = 'casper-java-sdk'
             from components.java
             pom {
                 name = 'Casper Java SDK'


### PR DESCRIPTION
rename `casper-sdk` -> `casper-java-sdk`