### PR TITLE
Issues/249 - Fixes for byte serialisation of CLValues type when nested in collection types such as maps and lists etc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ apply plugin: 'java'
 
 group = 'network.casper'
 // Version number update for release
-version='2.5.1'
+version='2.5.2'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 

--- a/src/main/java/com/casper/sdk/model/clvalue/AbstractCLValue.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/AbstractCLValue.java
@@ -49,17 +49,17 @@ public abstract class AbstractCLValue<T, P extends AbstractCLType>
         return this.value;
     }
 
-    public void setValue(T value) throws ValueSerializationException {
+    public void setValue(final T value) throws ValueSerializationException {
         this.value = value;
         this.serialize(new SerializerBuffer());
     }
 
-    public static AbstractCLValue<?, ?> createInstanceFromBytes(DeserializerBuffer deser) throws ValueDeserializationException {
-        int length = deser.readI32();
-        byte[] bytes = deser.readByteArray(length);
-        byte clType = deser.readU8();
+    public static AbstractCLValue<?, ?> createInstanceFromBytes(final DeserializerBuffer deser) throws ValueDeserializationException {
+        final int length = deser.readI32();
+        final byte[] bytes = deser.readByteArray(length);
+        final byte clType = deser.readU8();
         try {
-            AbstractCLValue<?, ?> clValue = CLTypeData.getTypeBySerializationTag(clType).getClazz().getDeclaredConstructor().newInstance();
+            final AbstractCLValue<?, ?> clValue = CLTypeData.getTypeBySerializationTag(clType).getClazz().getDeclaredConstructor().newInstance();
             clValue.deserializeCustom(new DeserializerBuffer(Hex.encode(bytes)));
             return clValue;
         } catch (Exception e) {
@@ -71,7 +71,7 @@ public abstract class AbstractCLValue<T, P extends AbstractCLType>
     @JsonGetter(value = "bytes")
     @ExcludeFromJacocoGeneratedReport
     protected String getJsonBytes() {
-        SerializerBuffer ser = new SerializerBuffer();
+        final SerializerBuffer ser = new SerializerBuffer();
         this.serialize(ser, Target.JSON);
 
         this.bytes = ByteUtils.encodeHexString(ser.toByteArray());
@@ -82,10 +82,10 @@ public abstract class AbstractCLValue<T, P extends AbstractCLType>
     @SneakyThrows({ValueDeserializationException.class})
     @JsonSetter(value = "bytes")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonBytes(String bytes) {
+    protected void setJsonBytes(final String bytes) {
         this.bytes = bytes;
 
-        DeserializerBuffer deser = new DeserializerBuffer(this.bytes);
+        final DeserializerBuffer deser = new DeserializerBuffer(this.bytes);
 
         this.deserialize(deser);
     }
@@ -96,15 +96,15 @@ public abstract class AbstractCLValue<T, P extends AbstractCLType>
     public abstract void setClType(P value);
 
 
-    protected void serializePrefixWithLength(SerializerBuffer ser) throws ValueSerializationException {
-        SerializerBuffer localSer = new SerializerBuffer();
+    protected void serializePrefixWithLength(final SerializerBuffer ser) throws ValueSerializationException {
+        final SerializerBuffer localSer = new SerializerBuffer();
         serialize(localSer);
-        int size = localSer.toByteArray().length;
+        final int size = localSer.toByteArray().length;
         ser.writeI32(size);
     }
 
     @Override
-    public AbstractCLValue<?, ?> deserialize(DeserializerBuffer deser, Target target) throws ValueDeserializationException {
+    public AbstractCLValue<?, ?> deserialize(final DeserializerBuffer deser, final Target target) throws ValueDeserializationException {
         if (target.equals(Target.BYTE)) {
             return AbstractCLValue.createInstanceFromBytes(deser);
         } else {
@@ -114,7 +114,7 @@ public abstract class AbstractCLValue<T, P extends AbstractCLType>
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws ValueSerializationException, NoSuchTypeException {
+    public void serialize(final SerializerBuffer ser, final Target target) throws ValueSerializationException, NoSuchTypeException {
         if (this.getValue() == null) return;
 
         if (target.equals(Target.BYTE)) {
@@ -128,13 +128,12 @@ public abstract class AbstractCLValue<T, P extends AbstractCLType>
         }
     }
 
-
     protected abstract void serializeValue(final SerializerBuffer ser) throws ValueSerializationException;
 
-    public abstract void deserializeCustom(DeserializerBuffer deserializerBuffer) throws Exception;
+    public abstract void deserializeCustom(final DeserializerBuffer deserializerBuffer) throws Exception;
 
     @Override
-    public void deserialize(DeserializerBuffer deserializerBuffer) throws ValueDeserializationException {
+    public void deserialize(final DeserializerBuffer deserializerBuffer) throws ValueDeserializationException {
         try {
             this.deserializeCustom(deserializerBuffer);
         } catch (Exception e) {
@@ -142,8 +141,8 @@ public abstract class AbstractCLValue<T, P extends AbstractCLType>
         }
     }
 
-    protected void encodeType(SerializerBuffer ser) throws NoSuchTypeException {
-        byte typeTag = (getClType().getClTypeData().getSerializationTag());
+    protected void encodeType(final SerializerBuffer ser) throws NoSuchTypeException {
+        final byte typeTag = (getClType().getClTypeData().getSerializationTag());
         ser.writeU8(typeTag);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/AbstractCLValue.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/AbstractCLValue.java
@@ -114,7 +114,22 @@ public abstract class AbstractCLValue<T, P extends AbstractCLType>
     }
 
     @Override
-    public abstract void serialize(SerializerBuffer ser, Target target) throws ValueSerializationException, NoSuchTypeException;
+    public void serialize(SerializerBuffer ser, Target target) throws ValueSerializationException, NoSuchTypeException {
+        if (this.getValue() == null) return;
+
+        if (target.equals(Target.BYTE)) {
+            serializePrefixWithLength(ser);
+        }
+
+        serializeValue(ser);
+
+        if (target.equals(Target.BYTE)) {
+            this.encodeType(ser);
+        }
+    }
+
+
+    protected abstract void serializeValue(final SerializerBuffer ser) throws ValueSerializationException;
 
     public abstract void deserializeCustom(DeserializerBuffer deserializerBuffer) throws Exception;
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueAny.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueAny.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeAny;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -49,14 +47,13 @@ public class CLValueAny extends AbstractCLValue<byte[], CLTypeAny> {
     }
 
     @Override
-    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
         ser.writeByteArray(this.getValue());
         this.setBytes(Hex.toHexString(this.getValue()));
     }
 
     @Override
-    public void deserializeCustom(final DeserializerBuffer deser)
-            throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(deser.readByteArray(deser.getBuffer().remaining()));
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueAny.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueAny.java
@@ -49,19 +49,9 @@ public class CLValueAny extends AbstractCLValue<byte[], CLTypeAny> {
     }
 
     @Override
-    public void serialize(final SerializerBuffer ser, final Target target) throws ValueSerializationException, NoSuchTypeException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
         ser.writeByteArray(this.getValue());
         this.setBytes(Hex.toHexString(this.getValue()));
-
-        if (target == Target.BYTE) {
-            this.encodeType(ser);
-        }
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueBool.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueBool.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeBool;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -14,7 +12,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.bouncycastle.util.encoders.Hex;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Casper Bool CLValue implementation
@@ -33,7 +30,7 @@ public class CLValueBool extends AbstractCLValue<Boolean, CLTypeBool> {
 
     @JsonSetter("cl_type")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(CLTypeBool clType) {
+    protected void setJsonClType(final CLTypeBool clType) {
         this.clType = clType;
     }
 
@@ -43,18 +40,18 @@ public class CLValueBool extends AbstractCLValue<Boolean, CLTypeBool> {
         return this.getClType().getTypeName();
     }
 
-    public CLValueBool(Boolean value) throws ValueSerializationException {
+    public CLValueBool(final Boolean value) throws ValueSerializationException {
         this.setValue(value);
     }
 
     @Override
-    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
         ser.writeBool(this.getValue());
         this.setBytes(Hex.toHexString(ser.toByteArray()));
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(deser.readBool());
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueBool.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueBool.java
@@ -48,19 +48,8 @@ public class CLValueBool extends AbstractCLValue<Boolean, CLTypeBool> {
     }
 
     @Override
-    public void serialize(@NotNull SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
         ser.writeBool(this.getValue());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
         this.setBytes(Hex.toHexString(ser.toByteArray()));
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueByteArray.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueByteArray.java
@@ -3,7 +3,6 @@ package com.casper.sdk.model.clvalue;
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
 import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeByteArray;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.oak3.sbs4j.DeserializerBuffer;
 import dev.oak3.sbs4j.SerializerBuffer;
@@ -32,25 +31,25 @@ public class CLValueByteArray extends AbstractCLValue<byte[], CLTypeByteArray> {
     @JsonProperty("cl_type")
     private CLTypeByteArray clType = new CLTypeByteArray();
 
-    public CLValueByteArray(byte[] value) throws ValueSerializationException {
+    public CLValueByteArray(final byte[] value) throws ValueSerializationException {
         this.setValue(value);
         this.clType.setLength(value.length);
     }
 
     @Override
-    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
         ser.writeByteArray(this.getValue());
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+        this.setBytes(Hex.toHexString(getValue()));
     }
 
     @Override
-    protected void encodeType(SerializerBuffer ser) throws NoSuchTypeException {
+    protected void encodeType(final SerializerBuffer ser) throws NoSuchTypeException {
         super.encodeType(ser);
         ser.writeI32(this.getClType().getLength());
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(deser.readByteArray(this.getClType().getLength()));
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueByteArray.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueByteArray.java
@@ -38,26 +38,14 @@ public class CLValueByteArray extends AbstractCLValue<byte[], CLTypeByteArray> {
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
         ser.writeByteArray(this.getValue());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
         this.setBytes(Hex.toHexString(ser.toByteArray()));
     }
 
     @Override
     protected void encodeType(SerializerBuffer ser) throws NoSuchTypeException {
         super.encodeType(ser);
-
         ser.writeI32(this.getClType().getLength());
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueI32.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueI32.java
@@ -38,13 +38,13 @@ public class CLValueI32 extends AbstractCLValue<Integer, CLTypeI32> {
         return this.getClType().getTypeName();
     }
 
-    public CLValueI32(Integer value) throws ValueSerializationException {
+    public CLValueI32(final Integer value) throws ValueSerializationException {
         this.setValue(value);
     }
 
     @Override
-    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
-       final SerializerBuffer serVal = new SerializerBuffer();
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
+        final SerializerBuffer serVal = new SerializerBuffer();
         serVal.writeI32(this.getValue());
         final byte[] bytes = serVal.toByteArray();
         ser.writeByteArray(bytes);
@@ -52,7 +52,7 @@ public class CLValueI32 extends AbstractCLValue<Integer, CLTypeI32> {
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(deser.readI32());
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueI32.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueI32.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeI32;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -45,20 +43,12 @@ public class CLValueI32 extends AbstractCLValue<Integer, CLTypeI32> {
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
-        ser.writeI32(this.getValue());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
+       final SerializerBuffer serVal = new SerializerBuffer();
+        serVal.writeI32(this.getValue());
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueI64.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueI64.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeI64;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -32,7 +30,7 @@ public class CLValueI64 extends AbstractCLValue<Long, CLTypeI64> {
 
     @JsonSetter("cl_type")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(CLTypeI64 clType) {
+    protected void setJsonClType(final CLTypeI64 clType) {
         this.clType = clType;
     }
 
@@ -42,20 +40,21 @@ public class CLValueI64 extends AbstractCLValue<Long, CLTypeI64> {
         return this.getClType().getTypeName();
     }
 
-    public CLValueI64(Long value) throws ValueSerializationException {
+    public CLValueI64(final Long value) throws ValueSerializationException {
         this.setValue(value);
     }
 
     @Override
-    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
-        ser.writeI64(this.getValue());
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
         final SerializerBuffer serVal = new SerializerBuffer();
         serVal.writeI64(this.getValue());
-        this.setBytes(Hex.toHexString(serVal.toByteArray()));
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(deser.readI64());
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueI64.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueI64.java
@@ -47,20 +47,11 @@ public class CLValueI64 extends AbstractCLValue<Long, CLTypeI64> {
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
         ser.writeI64(this.getValue());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+        final SerializerBuffer serVal = new SerializerBuffer();
+        serVal.writeI64(this.getValue());
+        this.setBytes(Hex.toHexString(serVal.toByteArray()));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueKey.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueKey.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeKey;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.casper.sdk.model.key.Key;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -15,7 +13,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.bouncycastle.util.encoders.Hex;
 
 /**
  * Casper Key CLValue implementation
@@ -34,7 +31,7 @@ public class CLValueKey extends AbstractCLValue<Key, CLTypeKey> {
 
     @JsonSetter("cl_type")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(CLTypeKey clType) {
+    protected void setJsonClType(final CLTypeKey clType) {
         this.clType = clType;
     }
 
@@ -44,7 +41,7 @@ public class CLValueKey extends AbstractCLValue<Key, CLTypeKey> {
         return this.getClType().getTypeName();
     }
 
-    public CLValueKey(Key value) throws ValueSerializationException {
+    public CLValueKey(final Key value) throws ValueSerializationException {
         this.setValue(value);
     }
 
@@ -56,7 +53,7 @@ public class CLValueKey extends AbstractCLValue<Key, CLTypeKey> {
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(Key.fromTaggedHexString(ByteUtils.encodeHexString(deser.readByteArray(33))));
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueKey.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueKey.java
@@ -49,21 +49,10 @@ public class CLValueKey extends AbstractCLValue<Key, CLTypeKey> {
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
         ser.writeU8(this.getValue().getTag().getByteTag());
         ser.writeByteArray(this.getValue().getKey());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+        this.setBytes(this.getValue().getAlgoTaggedHex());
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueList.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueList.java
@@ -49,12 +49,7 @@ public class CLValueList extends AbstractCLValueWithChildren<List<? extends Abst
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws ValueSerializationException, NoSuchTypeException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
 
         setChildTypes(this.getValue());
 
@@ -64,10 +59,6 @@ public class CLValueList extends AbstractCLValueWithChildren<List<? extends Abst
 
         for (AbstractCLValue<?, ?> child : getValue()) {
             child.serialize(ser);
-        }
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
         }
 
         this.setBytes(Hex.toHexString(ser.toByteArray()));

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueMap.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueMap.java
@@ -4,7 +4,6 @@ import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
 import com.casper.sdk.model.clvalue.cltype.CLTypeMap;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -50,14 +49,9 @@ public class CLValueMap extends
         this.setValue(value);
     }
 
+
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws ValueSerializationException, NoSuchTypeException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
         setChildTypes(this.getValue());
 
         CLValueI32 mapLength = new CLValueI32(getValue().size());
@@ -67,11 +61,6 @@ public class CLValueMap extends
             entry.getKey().serialize(ser);
             entry.getValue().serialize(ser);
         }
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
         this.setBytes(Hex.toHexString(ser.toByteArray()));
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueMap.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueMap.java
@@ -44,48 +44,54 @@ public class CLValueMap extends
         childTypesSet();
     }
 
-    public CLValueMap(Map<? extends AbstractCLValue<?, ?>, ? extends AbstractCLValue<?, ?>> value) throws ValueSerializationException {
+    public CLValueMap(final Map<? extends AbstractCLValue<?, ?>, ? extends AbstractCLValue<?, ?>> value) throws ValueSerializationException {
         setChildTypes(value);
         this.setValue(value);
     }
 
 
     @Override
-    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
+
+        final SerializerBuffer serVal = new SerializerBuffer();
+
         setChildTypes(this.getValue());
 
-        CLValueI32 mapLength = new CLValueI32(getValue().size());
-        mapLength.serialize(ser);
+        final CLValueI32 mapLength = new CLValueI32(getValue().size());
+        mapLength.serialize(serVal);
 
         for (Entry<? extends AbstractCLValue<?, ?>, ? extends AbstractCLValue<?, ?>> entry : getValue().entrySet()) {
-            entry.getKey().serialize(ser);
-            entry.getValue().serialize(ser);
+            entry.getKey().serialize(serVal);
+            entry.getValue().serialize(serVal);
         }
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override
-    protected void encodeType(SerializerBuffer ser) throws NoSuchTypeException {
+    protected void encodeType(final SerializerBuffer ser) throws NoSuchTypeException {
         super.encodeType(ser);
 
-        byte keyTypeTag = (getClType().getKeyValueTypes().getKeyType().getClTypeData().getSerializationTag());
+        final byte keyTypeTag = (getClType().getKeyValueTypes().getKeyType().getClTypeData().getSerializationTag());
         ser.writeU8(keyTypeTag);
 
-        byte valueTypeTag = (getClType().getKeyValueTypes().getValueType().getClTypeData().getSerializationTag());
+        final byte valueTypeTag = (getClType().getKeyValueTypes().getValueType().getClTypeData().getSerializationTag());
         ser.writeU8(valueTypeTag);
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
-        CLTypeData keyType = clType.getKeyValueTypes().getKeyType().getClTypeData();
-        CLTypeData valType = clType.getKeyValueTypes().getValueType().getClTypeData();
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
+        final CLTypeData keyType = clType.getKeyValueTypes().getKeyType().getClTypeData();
+        final CLTypeData valType = clType.getKeyValueTypes().getValueType().getClTypeData();
 
-        Map<AbstractCLValue<?, ?>, AbstractCLValue<?, ?>> map = new LinkedHashMap<>();
-        CLValueI32 mapLength = new CLValueI32(0);
+        final Map<AbstractCLValue<?, ?>, AbstractCLValue<?, ?>> map = new LinkedHashMap<>();
+        final CLValueI32 mapLength = new CLValueI32(0);
         mapLength.deserializeCustom(deser);
 
         for (int i = 0; i < mapLength.getValue(); i++) {
-            AbstractCLValue<?, ?> key = CLTypeData.createCLValueFromCLTypeData(keyType);
+            final AbstractCLValue<?, ?> key = CLTypeData.createCLValueFromCLTypeData(keyType);
             if (key.getClType() instanceof AbstractCLTypeWithChildren) {
                 ((AbstractCLTypeWithChildren) key.getClType())
                         .setChildTypes(
@@ -93,7 +99,7 @@ public class CLValueMap extends
             }
             key.deserializeCustom(deser);
 
-            AbstractCLValue<?, ?> val = CLTypeData.createCLValueFromCLTypeData(valType);
+            final AbstractCLValue<?, ?> val = CLTypeData.createCLValueFromCLTypeData(valType);
 
             if (val.getClType() instanceof CLTypeMap) {
                 ((CLTypeMap) val.getClType())
@@ -113,9 +119,9 @@ public class CLValueMap extends
 
     @Override
     @JsonIgnore
-    protected void setChildTypes(Map<? extends AbstractCLValue<?, ?>, ? extends AbstractCLValue<?, ?>> value) {
+    protected void setChildTypes(final Map<? extends AbstractCLValue<?, ?>, ? extends AbstractCLValue<?, ?>> value) {
         if (value != null && value.entrySet().iterator().hasNext()) {
-            Entry<? extends AbstractCLValue<?, ?>, ? extends AbstractCLValue<?, ?>> entry = value.entrySet().iterator().next();
+            final Entry<? extends AbstractCLValue<?, ?>, ? extends AbstractCLValue<?, ?>> entry = value.entrySet().iterator().next();
             clType.setKeyValueTypes(new CLTypeMap.CLTypeMapEntryType(entry.getKey().getClType(), entry.getValue().getClType()));
         } else {
             clType.setChildTypes(new ArrayList<>());

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueOption.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueOption.java
@@ -54,11 +54,27 @@ public class CLValueOption extends AbstractCLValueWithChildren<Optional<Abstract
             super.serializePrefixWithLength(ser);
         }
 
+        Optional<AbstractCLValue<?, ?>> child = getValue();
+
+        this.serializeValue(ser);
+
+        // FIXME TIDY THIS UP
+        if (target.equals(Target.BYTE)) {
+            this.encodeType(ser);
+            if (child.isPresent()) {
+                child.get().encodeType(ser);
+            }
+        }
+    }
+
+    @Override
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
         Optional<AbstractCLValue<?, ?>> value = getValue();
 
         CLValueBool isPresent = new CLValueBool(value.isPresent() && value.get().getValue() != null);
         isPresent.serialize(ser);
 
+        // FIXME Duplication of getValue()
         Optional<AbstractCLValue<?, ?>> child = getValue();
 
         if (child.isPresent() && child.get().getClType() instanceof AbstractCLTypeWithChildren) {
@@ -67,13 +83,6 @@ public class CLValueOption extends AbstractCLValueWithChildren<Optional<Abstract
         }
         if (child.isPresent() && isPresent.getValue().equals(Boolean.TRUE)) {
             child.get().serialize(ser);
-        }
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-            if (child.isPresent()) {
-                child.get().encodeType(ser);
-            }
         }
 
         this.setBytes(Hex.toHexString(ser.toByteArray()));

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValuePublicKey.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValuePublicKey.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypePublicKey;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.casper.sdk.model.key.PublicKey;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -33,7 +31,7 @@ public class CLValuePublicKey extends AbstractCLValue<PublicKey, CLTypePublicKey
 
     @JsonSetter("cl_type")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(CLTypePublicKey clType) {
+    protected void setJsonClType(final CLTypePublicKey clType) {
         this.clType = clType;
     }
 
@@ -43,19 +41,19 @@ public class CLValuePublicKey extends AbstractCLValue<PublicKey, CLTypePublicKey
         return this.getClType().getTypeName();
     }
 
-    public CLValuePublicKey(PublicKey value) throws ValueSerializationException {
+    public CLValuePublicKey(final PublicKey value) throws ValueSerializationException {
         this.setValue(value);
     }
 
     @Override
-    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
         ser.writeU8(this.getValue().getTag().getByteTag());
         ser.writeByteArray(this.getValue().getKey());
         this.setBytes(this.getValue().getAlgoTaggedHex());
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(PublicKey.fromTaggedHexString(ByteUtils.encodeHexString(deser.readByteArray(33))));
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValuePublicKey.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValuePublicKey.java
@@ -15,7 +15,6 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
-import org.bouncycastle.util.encoders.Hex;
 
 /**
  * Casper PublicKey CLValue implementation
@@ -49,21 +48,10 @@ public class CLValuePublicKey extends AbstractCLValue<PublicKey, CLTypePublicKey
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
         ser.writeU8(this.getValue().getTag().getByteTag());
         ser.writeByteArray(this.getValue().getKey());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+        this.setBytes(this.getValue().getAlgoTaggedHex());
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueResult.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueResult.java
@@ -53,14 +53,10 @@ public class CLValueResult extends AbstractCLValue<CLValueResult.Result, CLTypeR
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws ValueSerializationException, NoSuchTypeException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
         setChildTypes(this.getValue().getOk(), this.getValue().getErr());
+
+        SerializerBuffer serValue = new SerializerBuffer();
 
         CLValueBool clValueTrue = new CLValueBool(true);
         clValueTrue.serialize(ser);
@@ -72,10 +68,7 @@ public class CLValueResult extends AbstractCLValue<CLValueResult.Result, CLTypeR
 
         getValue().getErr().serialize(ser);
 
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
+        // FIXME This cannot use ser when is nested
         this.setBytes(Hex.toHexString(ser.toByteArray()));
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueResult.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueResult.java
@@ -1,10 +1,8 @@
 package com.casper.sdk.model.clvalue;
 
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
 import com.casper.sdk.model.clvalue.cltype.CLTypeResult;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.oak3.sbs4j.DeserializerBuffer;
 import dev.oak3.sbs4j.SerializerBuffer;
@@ -47,7 +45,7 @@ public class CLValueResult extends AbstractCLValue<CLValueResult.Result, CLTypeR
     @JsonProperty("cl_type")
     private CLTypeResult clType = new CLTypeResult();
 
-    public CLValueResult(AbstractCLValue<?, ?> ok, AbstractCLValue<?, ?> err) throws ValueSerializationException {
+    public CLValueResult(final AbstractCLValue<?, ?> ok, final AbstractCLValue<?, ?> err) throws ValueSerializationException {
         setChildTypes(ok, err);
         this.setValue(new Result(ok, err));
     }
@@ -56,29 +54,31 @@ public class CLValueResult extends AbstractCLValue<CLValueResult.Result, CLTypeR
     protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
         setChildTypes(this.getValue().getOk(), this.getValue().getErr());
 
-        SerializerBuffer serValue = new SerializerBuffer();
+        SerializerBuffer serVal = new SerializerBuffer();
 
         CLValueBool clValueTrue = new CLValueBool(true);
-        clValueTrue.serialize(ser);
+        clValueTrue.serialize(serVal);
 
-        getValue().getOk().serialize(ser);
+        getValue().getOk().serialize(serVal);
 
         CLValueBool clValueFalse = new CLValueBool(false);
-        clValueFalse.serialize(ser);
+        clValueFalse.serialize(serVal);
 
-        getValue().getErr().serialize(ser);
+        getValue().getErr().serialize(serVal);
 
-        // FIXME This cannot use ser when is nested
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
-        Result result = new Result();
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
+        final Result result = new Result();
         CLValueBool bool = new CLValueBool();
         bool.setValue(deser.readBool());
-        CLTypeData typeOk = clType.getOkErrTypes().getOkClType().getClTypeData();
-        AbstractCLValue<?, ?> clValueOk = CLTypeData.createCLValueFromCLTypeData(typeOk);
+        final CLTypeData typeOk = clType.getOkErrTypes().getOkClType().getClTypeData();
+        final AbstractCLValue<?, ?> clValueOk = CLTypeData.createCLValueFromCLTypeData(typeOk);
         if (clValueOk.getClType() instanceof AbstractCLTypeWithChildren) {
             ((AbstractCLTypeWithChildren) clValueOk.getClType()).getChildTypes()
                     .addAll(((AbstractCLTypeWithChildren) clType.getOkErrTypes().getOkClType()).getChildTypes());
@@ -88,8 +88,8 @@ public class CLValueResult extends AbstractCLValue<CLValueResult.Result, CLTypeR
 
         bool = new CLValueBool();
         bool.deserializeCustom(deser);
-        CLTypeData typeErr = clType.getOkErrTypes().getErrClType().getClTypeData();
-        AbstractCLValue<?, ?> clValueErr = CLTypeData.createCLValueFromCLTypeData(typeErr);
+        final CLTypeData typeErr = clType.getOkErrTypes().getErrClType().getClTypeData();
+        final AbstractCLValue<?, ?> clValueErr = CLTypeData.createCLValueFromCLTypeData(typeErr);
         if (clValueErr.getClType() instanceof AbstractCLTypeWithChildren) {
             ((AbstractCLTypeWithChildren) clValueErr.getClType()).getChildTypes()
                     .addAll(((AbstractCLTypeWithChildren) clType.getOkErrTypes().getErrClType()).getChildTypes());
@@ -100,7 +100,7 @@ public class CLValueResult extends AbstractCLValue<CLValueResult.Result, CLTypeR
         setValue(result);
     }
 
-    protected void setChildTypes(AbstractCLValue<?, ?> ok, AbstractCLValue<?, ?> err) {
+    protected void setChildTypes(final AbstractCLValue<?, ?> ok, AbstractCLValue<?, ?> err) {
         clType.setOkErrTypes(
                 new CLTypeResult.CLTypeResultOkErrTypes(ok.getClType(), err.getClType()));
     }

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueString.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueString.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeString;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -32,7 +30,7 @@ public class CLValueString extends AbstractCLValue<String, CLTypeString> {
 
     @JsonSetter("cl_type")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(CLTypeString clType) {
+    protected void setJsonClType(final CLTypeString clType) {
         this.clType = clType;
     }
 
@@ -42,21 +40,21 @@ public class CLValueString extends AbstractCLValue<String, CLTypeString> {
         return this.getClType().getTypeName();
     }
 
-    public CLValueString(String value) throws ValueSerializationException {
+    public CLValueString(final String value) throws ValueSerializationException {
         this.setValue(value);
     }
 
     @Override
-    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
         final SerializerBuffer serVal = new SerializerBuffer();
         serVal.writeString(this.getValue());
-        byte[] bytes = serVal.toByteArray();
-       ser.writeByteArray(bytes);
-       this.setBytes(Hex.toHexString(bytes));
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(deser.readString());
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueString.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueString.java
@@ -47,20 +47,12 @@ public class CLValueString extends AbstractCLValue<String, CLTypeString> {
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
-        ser.writeString(this.getValue());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
+        final SerializerBuffer serVal = new SerializerBuffer();
+        serVal.writeString(this.getValue());
+        byte[] bytes = serVal.toByteArray();
+       ser.writeByteArray(bytes);
+       this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple1.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple1.java
@@ -4,7 +4,6 @@ import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
 import com.casper.sdk.model.clvalue.cltype.CLTypeTuple1;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -18,7 +17,7 @@ import org.bouncycastle.util.encoders.Hex;
 import org.javatuples.Unit;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * Casper Tuple1 CLValue implementation
@@ -37,26 +36,28 @@ public class CLValueTuple1 extends AbstractCLValueWithChildren<Unit<? extends Ab
     private CLTypeTuple1 clType = new CLTypeTuple1();
 
     @JsonSetter("cl_type")
-    public void setClType(CLTypeTuple1 clType) {
+    public void setClType(final CLTypeTuple1 clType) {
         this.clType = clType;
         childTypesSet();
     }
 
-    public CLValueTuple1(Unit<? extends AbstractCLValue<?, ?>> value) throws ValueSerializationException {
+    public CLValueTuple1(final Unit<? extends AbstractCLValue<?, ?>> value) throws ValueSerializationException {
         setChildTypes(value);
         this.setValue(value);
     }
 
     @Override
-    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
+        final SerializerBuffer serVal = new SerializerBuffer();
         setChildTypes(this.getValue());
-        getValue().getValue0().serialize(ser);
-        // FIXME don't use ser as it can contain parent data
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+        getValue().getValue0().serialize(serVal);
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override
-    protected void encodeType(SerializerBuffer ser) throws NoSuchTypeException {
+    protected void encodeType(final SerializerBuffer ser) throws NoSuchTypeException {
         super.encodeType(ser);
 
         byte element0TypeTag = getClType().getChildClTypeData(0).getSerializationTag();
@@ -64,7 +65,7 @@ public class CLValueTuple1 extends AbstractCLValueWithChildren<Unit<? extends Ab
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         CLTypeData childTypeData1 = clType.getChildClTypeData(0);
 
         AbstractCLValue<?, ?> child1 = CLTypeData.createCLValueFromCLTypeData(childTypeData1);
@@ -78,9 +79,9 @@ public class CLValueTuple1 extends AbstractCLValueWithChildren<Unit<? extends Ab
     }
 
     @Override
-    protected void setChildTypes(Unit<? extends AbstractCLValue<?, ?>> value) {
+    protected void setChildTypes(final Unit<? extends AbstractCLValue<?, ?>> value) {
         if (value.getValue0() != null) {
-            clType.setChildTypes(Arrays.asList(value.getValue0().getClType()));
+            clType.setChildTypes(Collections.singletonList(value.getValue0().getClType()));
         } else {
             clType.setChildTypes(new ArrayList<>());
         }

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple1.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple1.java
@@ -48,20 +48,10 @@ public class CLValueTuple1 extends AbstractCLValueWithChildren<Unit<? extends Ab
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
         setChildTypes(this.getValue());
         getValue().getValue0().serialize(ser);
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
+        // FIXME don't use ser as it can contain parent data
         this.setBytes(Hex.toHexString(ser.toByteArray()));
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple2.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple2.java
@@ -4,7 +4,6 @@ import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
 import com.casper.sdk.model.clvalue.cltype.CLTypeTuple2;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -50,35 +49,39 @@ public class CLValueTuple2
 
     @Override
     protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
+        final SerializerBuffer serVal = new SerializerBuffer();
         setChildTypes(this.getValue());
-        getValue().getValue0().serialize(ser);
-        getValue().getValue1().serialize(ser);
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+        getValue().getValue0().serialize(serVal);
+        getValue().getValue1().serialize(serVal);
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
+
     }
 
     @Override
-    protected void encodeType(SerializerBuffer ser) throws NoSuchTypeException {
+    protected void encodeType(final SerializerBuffer ser) throws NoSuchTypeException {
         super.encodeType(ser);
 
-        byte element0TypeTag = getClType().getChildClTypeData(0).getSerializationTag();
+        final byte element0TypeTag = getClType().getChildClTypeData(0).getSerializationTag();
         ser.writeU8(element0TypeTag);
-        byte element1TypeTag = getClType().getChildClTypeData(1).getSerializationTag();
+        final byte element1TypeTag = getClType().getChildClTypeData(1).getSerializationTag();
         ser.writeU8(element1TypeTag);
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
-        CLTypeData childTypeData1 = clType.getChildClTypeData(0);
-        CLTypeData childTypeData2 = clType.getChildClTypeData(1);
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
+        final CLTypeData childTypeData1 = clType.getChildClTypeData(0);
+        final CLTypeData childTypeData2 = clType.getChildClTypeData(1);
 
-        AbstractCLValue<?, ?> child1 = CLTypeData.createCLValueFromCLTypeData(childTypeData1);
+        final AbstractCLValue<?, ?> child1 = CLTypeData.createCLValueFromCLTypeData(childTypeData1);
         if (child1.getClType() instanceof AbstractCLTypeWithChildren) {
             ((AbstractCLTypeWithChildren) child1.getClType())
                     .setChildTypes(((AbstractCLTypeWithChildren) clType.getChildTypes().get(0)).getChildTypes());
         }
         child1.deserializeCustom(deser);
 
-        AbstractCLValue<?, ?> child2 = CLTypeData.createCLValueFromCLTypeData(childTypeData2);
+        final AbstractCLValue<?, ?> child2 = CLTypeData.createCLValueFromCLTypeData(childTypeData2);
         if (child2.getClType() instanceof AbstractCLTypeWithChildren) {
             ((AbstractCLTypeWithChildren) child2.getClType())
                     .setChildTypes(((AbstractCLTypeWithChildren) clType.getChildTypes().get(1)).getChildTypes());
@@ -89,7 +92,7 @@ public class CLValueTuple2
     }
 
     @Override
-    protected void setChildTypes(Pair<? extends AbstractCLValue<?, ?>, ? extends AbstractCLValue<?, ?>> value) {
+    protected void setChildTypes(final Pair<? extends AbstractCLValue<?, ?>, ? extends AbstractCLValue<?, ?>> value) {
         if (value.getValue0() != null && value.getValue1() != null) {
             clType.setChildTypes(Arrays.asList(value.getValue0().getClType(), value.getValue1().getClType()));
         } else {

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple2.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple2.java
@@ -49,21 +49,10 @@ public class CLValueTuple2
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
         setChildTypes(this.getValue());
         getValue().getValue0().serialize(ser);
         getValue().getValue1().serialize(ser);
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
         this.setBytes(Hex.toHexString(ser.toByteArray()));
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple3.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple3.java
@@ -4,7 +4,6 @@ import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
 import com.casper.sdk.model.clvalue.cltype.CLTypeTuple3;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -50,12 +49,14 @@ public class CLValueTuple3 extends
 
     @Override
     protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
+        SerializerBuffer serVal = new SerializerBuffer();
         setChildTypes(this.getValue());
-        getValue().getValue0().serialize(ser);
-        getValue().getValue1().serialize(ser);
-        getValue().getValue2().serialize(ser);
-        // FIXME Don't use ser as it can contain parent data
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+        getValue().getValue0().serialize(serVal);
+        getValue().getValue1().serialize(serVal);
+        getValue().getValue2().serialize(serVal);
+        byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple3.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple3.java
@@ -49,23 +49,12 @@ public class CLValueTuple3 extends
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
         setChildTypes(this.getValue());
-
         getValue().getValue0().serialize(ser);
         getValue().getValue1().serialize(ser);
         getValue().getValue2().serialize(ser);
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
+        // FIXME Don't use ser as it can contain parent data
         this.setBytes(Hex.toHexString(ser.toByteArray()));
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueU128.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueU128.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeU128;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -34,7 +32,7 @@ public class CLValueU128 extends AbstractCLValue<BigInteger, CLTypeU128> {
 
     @JsonSetter("cl_type")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(CLTypeU128 clType) {
+    protected void setJsonClType(final CLTypeU128 clType) {
         this.clType = clType;
     }
 
@@ -44,7 +42,7 @@ public class CLValueU128 extends AbstractCLValue<BigInteger, CLTypeU128> {
         return this.getClType().getTypeName();
     }
 
-    public CLValueU128(BigInteger value) throws ValueSerializationException {
+    public CLValueU128(final BigInteger value) throws ValueSerializationException {
         this.setValue(value);
     }
 
@@ -58,7 +56,7 @@ public class CLValueU128 extends AbstractCLValue<BigInteger, CLTypeU128> {
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(deser.readU128());
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueU128.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueU128.java
@@ -49,20 +49,12 @@ public class CLValueU128 extends AbstractCLValue<BigInteger, CLTypeU128> {
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws ValueSerializationException, NoSuchTypeException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
-        ser.writeU128(this.getValue());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
+        final SerializerBuffer serVal = new SerializerBuffer();
+        serVal.writeU128(this.getValue());
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueU256.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueU256.java
@@ -49,20 +49,12 @@ public class CLValueU256 extends AbstractCLValue<BigInteger, CLTypeU256> {
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws ValueSerializationException, NoSuchTypeException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
-        ser.writeU256(this.getValue());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
+        final SerializerBuffer serVal = new SerializerBuffer();
+        serVal.writeU256(this.getValue());
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueU256.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueU256.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeU256;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -34,7 +32,7 @@ public class CLValueU256 extends AbstractCLValue<BigInteger, CLTypeU256> {
 
     @JsonSetter("cl_type")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(CLTypeU256 clType) {
+    protected void setJsonClType(final CLTypeU256 clType) {
         this.clType = clType;
     }
 
@@ -44,7 +42,7 @@ public class CLValueU256 extends AbstractCLValue<BigInteger, CLTypeU256> {
         return this.getClType().getTypeName();
     }
 
-    public CLValueU256(BigInteger value) throws ValueSerializationException {
+    public CLValueU256(final BigInteger value) throws ValueSerializationException {
         this.setValue(value);
     }
 
@@ -58,7 +56,7 @@ public class CLValueU256 extends AbstractCLValue<BigInteger, CLTypeU256> {
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(deser.readU256());
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueU32.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueU32.java
@@ -47,20 +47,12 @@ public class CLValueU32 extends AbstractCLValue<Long, CLTypeU32> {
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
-        ser.writeU32(this.getValue());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
+        final SerializerBuffer serVal = new SerializerBuffer();
+        serVal.writeU32(this.getValue());
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueU32.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueU32.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeU32;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -32,7 +30,7 @@ public class CLValueU32 extends AbstractCLValue<Long, CLTypeU32> {
 
     @JsonSetter("cl_type")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(CLTypeU32 clType) {
+    protected void setJsonClType(final CLTypeU32 clType) {
         this.clType = clType;
     }
 
@@ -42,7 +40,7 @@ public class CLValueU32 extends AbstractCLValue<Long, CLTypeU32> {
         return this.getClType().getTypeName();
     }
 
-    public CLValueU32(Long value) throws ValueSerializationException {
+    public CLValueU32(final Long value) throws ValueSerializationException {
         this.setValue(value);
     }
 
@@ -56,7 +54,7 @@ public class CLValueU32 extends AbstractCLValue<Long, CLTypeU32> {
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(deser.readU32());
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueU512.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueU512.java
@@ -47,20 +47,12 @@ public class CLValueU512 extends AbstractCLValue<BigInteger, CLTypeU512> {
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws ValueSerializationException, NoSuchTypeException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
-        ser.writeU512(this.getValue());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
+        final SerializerBuffer serVal = new SerializerBuffer();
+        serVal.writeU512(this.getValue());
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueU512.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueU512.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeU512;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -32,7 +30,7 @@ public class CLValueU512 extends AbstractCLValue<BigInteger, CLTypeU512> {
 
     @JsonSetter("cl_type")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(CLTypeU512 clType) {
+    protected void setJsonClType(final CLTypeU512 clType) {
         this.clType = clType;
     }
 
@@ -42,7 +40,7 @@ public class CLValueU512 extends AbstractCLValue<BigInteger, CLTypeU512> {
         return this.getClType().getTypeName();
     }
 
-    public CLValueU512(BigInteger value) throws ValueSerializationException {
+    public CLValueU512(final BigInteger value) throws ValueSerializationException {
         this.setValue(value);
     }
 
@@ -56,7 +54,7 @@ public class CLValueU512 extends AbstractCLValue<BigInteger, CLTypeU512> {
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(deser.readU512());
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueU64.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueU64.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeU64;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -32,7 +30,7 @@ public class CLValueU64 extends AbstractCLValue<BigInteger, CLTypeU64> {
 
     @JsonSetter("cl_type")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(CLTypeU64 clType) {
+    protected void setJsonClType(final CLTypeU64 clType) {
         this.clType = clType;
     }
 
@@ -42,7 +40,7 @@ public class CLValueU64 extends AbstractCLValue<BigInteger, CLTypeU64> {
         return this.getClType().getTypeName();
     }
 
-    public CLValueU64(BigInteger value) throws ValueSerializationException {
+    public CLValueU64(final BigInteger value) throws ValueSerializationException {
         this.setValue(value);
     }
 
@@ -56,7 +54,7 @@ public class CLValueU64 extends AbstractCLValue<BigInteger, CLTypeU64> {
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(deser.readU64());
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueU64.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueU64.java
@@ -47,20 +47,12 @@ public class CLValueU64 extends AbstractCLValue<BigInteger, CLTypeU64> {
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws ValueSerializationException, NoSuchTypeException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
-        ser.writeU64(this.getValue());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
+        final SerializerBuffer serVal = new SerializerBuffer();
+        serVal.writeU64(this.getValue());
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueU8.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueU8.java
@@ -47,20 +47,12 @@ public class CLValueU8 extends AbstractCLValue<Byte, CLTypeU8> {
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
-        ser.writeU8(this.getValue());
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
+        final SerializerBuffer serVal = new SerializerBuffer();
+        serVal.writeU8(this.getValue());
+        byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueU8.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueU8.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeU8;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -32,7 +30,7 @@ public class CLValueU8 extends AbstractCLValue<Byte, CLTypeU8> {
 
     @JsonSetter("cl_type")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(CLTypeU8 clType) {
+    protected void setJsonClType(final CLTypeU8 clType) {
         this.clType = clType;
     }
 
@@ -42,21 +40,21 @@ public class CLValueU8 extends AbstractCLValue<Byte, CLTypeU8> {
         return this.getClType().getTypeName();
     }
 
-    public CLValueU8(Byte value) throws ValueSerializationException {
+    public CLValueU8(final Byte value) throws ValueSerializationException {
         this.setValue(value);
     }
 
     @Override
-    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
         final SerializerBuffer serVal = new SerializerBuffer();
         serVal.writeU8(this.getValue());
-        byte[] bytes = serVal.toByteArray();
+        final byte[] bytes = serVal.toByteArray();
         ser.writeByteArray(bytes);
         this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
         this.setValue(deser.readU8());
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueURef.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueURef.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeURef;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.casper.sdk.model.uref.URef;
 import com.casper.sdk.model.uref.URefAccessRight;
 import com.fasterxml.jackson.annotation.JsonGetter;
@@ -37,7 +35,7 @@ import java.util.Objects;
 public class CLValueURef extends AbstractCLValue<URef, CLTypeURef> {
     private CLTypeURef clType = new CLTypeURef();
 
-    public CLValueURef(URef value) throws ValueSerializationException {
+    public CLValueURef(final URef value) throws ValueSerializationException {
         this.setValue(value);
     }
 
@@ -49,29 +47,30 @@ public class CLValueURef extends AbstractCLValue<URef, CLTypeURef> {
 
     @JsonSetter("cl_type")
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(CLTypeURef clType) {
+    protected void setJsonClType(final CLTypeURef clType) {
         this.clType = clType;
     }
 
-
     @Override
-    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
-        URef uref = this.getValue();
-        byte[] urefByte = new byte[uref.getAddress().length + 1];
+    protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
+        final SerializerBuffer serVal = new SerializerBuffer();
+        final URef uref = this.getValue();
+        final byte[] urefByte = new byte[uref.getAddress().length + 1];
         System.arraycopy(uref.getAddress(), 0, urefByte, 0, uref.getAddress().length);
         urefByte[32] = uref.getAccessRight().serializationTag;
-        ser.writeByteArray(urefByte);
-        // FIXME use a value SerializerBuffer to get the bytes
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
+        serVal.writeByteArray(urefByte);
+        final byte[] bytes = serVal.toByteArray();
+        ser.writeByteArray(bytes);
+        this.setBytes(Hex.toHexString(bytes));
     }
 
     @Override
-    public void deserializeCustom(DeserializerBuffer deser) throws Exception {
-        URef uref = new URef();
-        CLValueByteArray clValueByteArray = new CLValueByteArray(new byte[32]);
+    public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
+        final URef uref = new URef();
+        final CLValueByteArray clValueByteArray = new CLValueByteArray(new byte[32]);
         clValueByteArray.deserializeCustom(deser);
         uref.setAddress(clValueByteArray.getValue());
-        CLValueU8 serializationTag = new CLValueU8((byte) 0);
+        final CLValueU8 serializationTag = new CLValueU8((byte) 0);
         serializationTag.deserializeCustom(deser);
         uref.setAccessRight(URefAccessRight.getTypeBySerializationTag(serializationTag.getValue()));
         setValue(uref);

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueURef.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueURef.java
@@ -53,24 +53,15 @@ public class CLValueURef extends AbstractCLValue<URef, CLTypeURef> {
         this.clType = clType;
     }
 
+
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
         URef uref = this.getValue();
         byte[] urefByte = new byte[uref.getAddress().length + 1];
         System.arraycopy(uref.getAddress(), 0, urefByte, 0, uref.getAddress().length);
         urefByte[32] = uref.getAccessRight().serializationTag;
         ser.writeByteArray(urefByte);
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
+        // FIXME use a value SerializerBuffer to get the bytes
         this.setBytes(Hex.toHexString(ser.toByteArray()));
     }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueUnit.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueUnit.java
@@ -1,9 +1,7 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeUnit;
-import com.casper.sdk.model.clvalue.serde.Target;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -12,7 +10,6 @@ import dev.oak3.sbs4j.exception.ValueSerializationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import org.bouncycastle.util.encoders.Hex;
 
 /**
  * Casper Unit CLValue implementation
@@ -52,8 +49,6 @@ public class CLValueUnit extends AbstractCLValue<Object, CLTypeUnit> {
     @Override
     protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
         setBytes(UNITY_EMPTY_VALUE);
-        // FIXME use new SerializerBuffer()
-        this.setBytes(Hex.toHexString(ser.toByteArray()));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueUnit.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueUnit.java
@@ -50,19 +50,9 @@ public class CLValueUnit extends AbstractCLValue<Object, CLTypeUnit> {
     }
 
     @Override
-    public void serialize(SerializerBuffer ser, Target target) throws NoSuchTypeException, ValueSerializationException {
-        if (this.getValue() == null) return;
-
-        if (target.equals(Target.BYTE)) {
-            super.serializePrefixWithLength(ser);
-        }
-
+    protected void serializeValue(SerializerBuffer ser) throws ValueSerializationException {
         setBytes(UNITY_EMPTY_VALUE);
-
-        if (target.equals(Target.BYTE)) {
-            this.encodeType(ser);
-        }
-
+        // FIXME use new SerializerBuffer()
         this.setBytes(Hex.toHexString(ser.toByteArray()));
     }
 

--- a/src/main/java/com/casper/sdk/model/event/deployprocessed/DeployProcessed.java
+++ b/src/main/java/com/casper/sdk/model/event/deployprocessed/DeployProcessed.java
@@ -33,7 +33,7 @@ public class DeployProcessed implements EventData {
     private Digest account;
 
     @JsonProperty("timestamp")
-    private String timestamp; // TODO convert to data
+    private String timestamp; // TODO convert to date
 
     @JsonProperty("ttl")
     private String ttl;

--- a/src/main/java/com/casper/sdk/model/event/fault/Fault.java
+++ b/src/main/java/com/casper/sdk/model/event/fault/Fault.java
@@ -26,5 +26,5 @@ public class Fault implements EventData {
 
     /** A timestamp type, representing a concrete moment in time of the fault. */
     @JsonProperty("timestamp")
-    private String timestamp; // TODO convert to data
+    private String timestamp; // TODO convert to date
 }

--- a/src/test/java/com/casper/sdk/model/clvalue/CLValueTests.java
+++ b/src/test/java/com/casper/sdk/model/clvalue/CLValueTests.java
@@ -45,12 +45,12 @@ public class CLValueTests {
 
     @Test
     void createCLTypeFromCLTypeData_should_return_correct_CLType() throws DynamicInstanceException {
-        assertTrue(CLTypeData.createCLTypeFromCLTypeData(CLTypeData.ANY) instanceof CLTypeAny);
+        assertInstanceOf(CLTypeAny.class, CLTypeData.createCLTypeFromCLTypeData(CLTypeData.ANY));
     }
 
     @Test
     void createCLValueFromCLTypeName_should_return_correct_CLValue() throws DynamicInstanceException, NoSuchTypeException {
-        assertTrue(CLTypeData.createCLValueFromCLTypeName(CLTypeData.ANY.getClTypeName()) instanceof CLValueAny);
+        assertInstanceOf(CLValueAny.class, CLTypeData.createCLValueFromCLTypeName(CLTypeData.ANY.getClTypeName()));
     }
 
     @Test

--- a/src/test/java/com/casper/sdk/model/clvalue/CLValueTests.java
+++ b/src/test/java/com/casper/sdk/model/clvalue/CLValueTests.java
@@ -4,10 +4,15 @@ import com.casper.sdk.exception.DynamicInstanceException;
 import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeAny;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
+import com.casper.sdk.model.clvalue.cltype.CLTypeMap;
 import com.casper.sdk.model.clvalue.serde.Target;
 import com.syntifi.crypto.key.encdec.Hex;
+import dev.oak3.sbs4j.DeserializerBuffer;
 import dev.oak3.sbs4j.SerializerBuffer;
 import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -80,5 +85,46 @@ public class CLValueTests {
     @Test
     void getTypeByName_from_CLTypeData_should_throw_NoSuchTypeException() {
         assertThrows(NoSuchTypeException.class, () -> CLTypeData.getTypeByName("NE"));
+    }
+
+
+    @Test
+    void mapDeserialization() throws Exception {
+
+        final CLValueString key = new CLValueString("ONE");
+        final CLValueU32 value = new CLValueU32(2L);
+        final Map<CLValueString, CLValueU32> innerMap = new HashMap<>();
+        innerMap.put(key, value);
+        CLValueMap clValueMap = new CLValueMap(innerMap);
+
+        SerializerBuffer ser = new SerializerBuffer();
+        clValueMap.serialize(ser, Target.JSON);
+        byte[] bytes = ser.toByteArray();
+
+        byte[] expected = Hex.decode("01000000030000004f4e4502000000");
+        assertThat(bytes, is(expected));
+
+        ser = new SerializerBuffer();
+        clValueMap.serialize(ser, Target.BYTE);
+        bytes = ser.toByteArray();
+        expected = Hex.decode("0f00000001000000030000004f4e4502000000110a04");
+        assertThat(bytes, is(expected));
+
+        final CLValueMap deserialized = new CLValueMap();
+        CLTypeMap clTypeMap = new CLTypeMap();
+        clTypeMap.setKeyValueTypes(new CLTypeMap.CLTypeMapEntryType(key.getClType(), value.getClType()));
+        deserialized.setClType(clTypeMap);
+        deserialized.deserialize(new DeserializerBuffer("01000000030000004f4e4502000000"));
+        String hexBytes = deserialized.getBytes();
+        assertThat(hexBytes, is("01000000030000004f4e4502000000"));
+
+        CLValueString keyDeser = (CLValueString) deserialized.getValue().keySet().iterator().next();
+
+        assertThat(keyDeser, is(key));
+        assertThat(keyDeser.getBytes(), is(key.getBytes()));
+
+        CLValueU32 valueDeser = (CLValueU32) deserialized.getValue().get(key);
+        assertThat(valueDeser, is(value));
+        assertThat(valueDeser.getBytes(), is(value.getBytes()));
     }
 }

--- a/src/test/java/com/casper/sdk/model/clvalue/serde/SerializerDeserializerTests.java
+++ b/src/test/java/com/casper/sdk/model/clvalue/serde/SerializerDeserializerTests.java
@@ -70,7 +70,7 @@ public class SerializerDeserializerTests {
             new TestData<>(AbstractCLType.U512, new BigInteger("2500010000", 10), "0410200395", null, Target.JSON),
             new TestData<>(AbstractCLType.STRING, "the string", "0a00000074686520737472696e67", null, Target.JSON),
             new TestData<>(AbstractCLType.STRING, "Hello, World!", "0d00000048656c6c6f2c20576f726c6421", null, Target.JSON),
-            new TestData<>(AbstractCLType.STRING, "nested", "0a000000060000006e65737465640a", null, Target.BYTE));
+            new TestData<>(AbstractCLType.STRING, "nested", "060000006e6573746564", null, Target.JSON));
 
     private final List<TestData<?>> lastValidNumberTestDataList = Arrays.asList(
             new TestData<>(AbstractCLType.U64, SerializerBuffer.MAX_U64, null, null, Target.JSON),


### PR DESCRIPTION
Refactored so that the values bytes do not include the bytes of any parent value. Code has been changed to ensure each value have it's own SerializationBuffer that is used to provide its own bytes.