### PR TITLE
Issues/253 - Refactor for defects in byte serialization and desieralization of AbstractCLTypeWithChildren

### DIFF
--- a/src/main/java/com/casper/sdk/helper/CasperDeployHelper.java
+++ b/src/main/java/com/casper/sdk/helper/CasperDeployHelper.java
@@ -39,9 +39,13 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CasperDeployHelper {
 
-    public static DeployHeader buildDeployHeader(PublicKey fromPublicKey, String chainName,
-                                                 Long gasPrice, Ttl ttl, Date date,
-                                                 List<Digest> dependencies, byte[] bodyHash) {
+    public static DeployHeader buildDeployHeader(final PublicKey fromPublicKey,
+                                                 final String chainName,
+                                                 final Long gasPrice,
+                                                 final Ttl ttl,
+                                                 final Date date,
+                                                 final List<Digest> dependencies,
+                                                 final byte[] bodyHash) {
         return DeployHeader
                 .builder()
                 .account(fromPublicKey)
@@ -54,28 +58,29 @@ public class CasperDeployHelper {
                 .build();
     }
 
-    public static HashAndSignature signDeployHeader(AbstractPrivateKey privateKey, DeployHeader deployHeader)
+    public static HashAndSignature signDeployHeader(final AbstractPrivateKey privateKey, final DeployHeader deployHeader)
             throws GeneralSecurityException, NoSuchTypeException, ValueSerializationException {
-        SerializerBuffer serializerBuffer = new SerializerBuffer();
-
+        final SerializerBuffer serializerBuffer = new SerializerBuffer();
         deployHeader.serialize(serializerBuffer, Target.BYTE);
-        byte[] headerHash = Blake2b.digest(serializerBuffer.toByteArray(), 32);
-        Signature signature = Signature.sign(privateKey, headerHash);
+        final byte[] headerHash = Blake2b.digest(serializerBuffer.toByteArray(), 32);
+        final Signature signature = Signature.sign(privateKey, headerHash);
         return new HashAndSignature(headerHash, signature);
     }
 
-    public static byte[] getDeployItemAndModuleBytesHash(ExecutableDeployItem deployItem, ModuleBytes moduleBytes)
+    public static byte[] getDeployItemAndModuleBytesHash(final ExecutableDeployItem deployItem, final ModuleBytes moduleBytes)
             throws NoSuchTypeException, ValueSerializationException {
-        SerializerBuffer ser = new SerializerBuffer();
+        final SerializerBuffer ser = new SerializerBuffer();
         moduleBytes.serialize(ser, Target.BYTE);
         deployItem.serialize(ser, Target.BYTE);
         return Blake2b.digest(ser.toByteArray(), 32);
     }
 
-    public static ModuleBytes getPaymentModuleBytes(BigInteger paymentAmount) throws ValueSerializationException {
-        List<NamedArg<?>> paymentArgs = new LinkedList<>();
-        NamedArg<CLTypeU512> paymentArg = new NamedArg<>("amount",
-                new CLValueU512(paymentAmount));
+    public static ModuleBytes getPaymentModuleBytes(final BigInteger paymentAmount) throws ValueSerializationException {
+        final List<NamedArg<?>> paymentArgs = new LinkedList<>();
+        final NamedArg<CLTypeU512> paymentArg = new NamedArg<>(
+                "amount",
+                new CLValueU512(paymentAmount)
+        );
         paymentArgs.add(paymentArg);
         return ModuleBytes
                 .builder()
@@ -96,26 +101,38 @@ public class CasperDeployHelper {
      *                       ms (30 minutes))
      * @param date           deploy date
      * @param dependencies   list of digest dependencies
-     * @return
+     * @return the built deploy
      * @throws NoSuchTypeException
      * @throws GeneralSecurityException
      * @throws ValueSerializationException
      */
-    public static Deploy buildDeploy(AbstractPrivateKey fromPrivateKey, String chainName,
-                                     ExecutableDeployItem session, ModuleBytes payment,
-                                     Long gasPrice, Ttl ttl, Date date, List<Digest> dependencies)
+    public static Deploy buildDeploy(final AbstractPrivateKey fromPrivateKey,
+                                     final String chainName,
+                                     final ExecutableDeployItem session,
+                                     final ModuleBytes payment,
+                                     final Long gasPrice,
+                                     final Ttl ttl,
+                                     final Date date,
+                                     final List<Digest> dependencies)
             throws NoSuchTypeException, GeneralSecurityException, ValueSerializationException {
 
-        byte[] sessionAnPaymentHash = getDeployItemAndModuleBytesHash(session, payment);
+        final byte[] sessionAnPaymentHash = getDeployItemAndModuleBytesHash(session, payment);
 
-        PublicKey fromPublicKey = PublicKey.fromAbstractPublicKey(fromPrivateKey.derivePublicKey());
+        final PublicKey fromPublicKey = PublicKey.fromAbstractPublicKey(fromPrivateKey.derivePublicKey());
 
-        DeployHeader deployHeader = buildDeployHeader(fromPublicKey, chainName, gasPrice, ttl,
-                date, dependencies, sessionAnPaymentHash);
+        final DeployHeader deployHeader = buildDeployHeader(
+                fromPublicKey,
+                chainName,
+                gasPrice,
+                ttl,
+                date,
+                dependencies,
+                sessionAnPaymentHash
+        );
 
-        HashAndSignature hashAndSignature = signDeployHeader(fromPrivateKey, deployHeader);
+        final HashAndSignature hashAndSignature = signDeployHeader(fromPrivateKey, deployHeader);
 
-        List<Approval> approvals = new LinkedList<>();
+        final List<Approval> approvals = new LinkedList<>();
         approvals.add(Approval.builder()
                 .signer(PublicKey.fromAbstractPublicKey(fromPrivateKey.derivePublicKey()))
                 .signature(hashAndSignature.getSignature())

--- a/src/main/java/com/casper/sdk/model/clvalue/AbstractCLValue.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/AbstractCLValue.java
@@ -1,13 +1,11 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.DynamicInstanceException;
 import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.jackson.resolver.CLValueResolver;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLType;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
-import com.casper.sdk.model.clvalue.cltype.CLTypeMap;
 import com.casper.sdk.model.clvalue.serde.CasperDeserializableObject;
 import com.casper.sdk.model.clvalue.serde.CasperSerializableObject;
 import com.casper.sdk.model.clvalue.serde.Target;
@@ -82,11 +80,6 @@ public abstract class AbstractCLValue<T, P extends AbstractCLType>
         return super.clone();
     }
 
-    protected CLTypeData deserializeTypeData(DeserializerBuffer dser) throws NoSuchTypeException, ValueDeserializationException {
-        byte clType = dser.readU8();
-        return CLTypeData.getTypeBySerializationTag(clType);
-    }
-
     @SneakyThrows({ValueSerializationException.class, NoSuchTypeException.class})
     @JsonGetter(value = "bytes")
     @ExcludeFromJacocoGeneratedReport
@@ -104,7 +97,7 @@ public abstract class AbstractCLValue<T, P extends AbstractCLType>
     @ExcludeFromJacocoGeneratedReport
     protected void setJsonBytes(final String bytes) {
         this.bytes = bytes;
-        this.deserialize( new DeserializerBuffer(this.bytes));
+        this.deserialize(new DeserializerBuffer(this.bytes));
     }
 
     @JsonIgnore
@@ -141,7 +134,7 @@ public abstract class AbstractCLValue<T, P extends AbstractCLType>
         serializeValue(ser);
 
         if (Target.BYTE.equals(target)) {
-            this.encodeType(ser);
+            getClType().serialize(ser);
         }
     }
 
@@ -156,10 +149,5 @@ public abstract class AbstractCLValue<T, P extends AbstractCLType>
         } catch (Exception e) {
             throw new ValueDeserializationException("Error deserializing value", e);
         }
-    }
-
-    protected void encodeType(final SerializerBuffer ser) throws NoSuchTypeException {
-        final byte typeTag = (getClType().getClTypeData().getSerializationTag());
-        ser.writeU8(typeTag);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/AbstractCLValueWithChildren.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/AbstractCLValueWithChildren.java
@@ -1,12 +1,9 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
-import com.casper.sdk.model.clvalue.cltype.CLTypeData;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
-import dev.oak3.sbs4j.SerializerBuffer;
 import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.EqualsAndHashCode;
 import lombok.SneakyThrows;
@@ -51,37 +48,5 @@ public abstract class AbstractCLValueWithChildren<T, P extends AbstractCLTypeWit
         if (!getClType().getChildTypes().isEmpty() && getClType().isDeserializable()) {
             this.deserialize(new DeserializerBuffer(this.getBytes()));
         }
-    }
-
-    protected void encodeType(final SerializerBuffer ser) throws NoSuchTypeException {
-        super.encodeType(ser);
-        encodeChildTypes(ser);
-    }
-
-    protected abstract void encodeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException;
-
-    /**
-     * Encodes the bytes of the child type, if the child value is not present but the type is known from the parent type
-     * info, the childDataType is used to encode the bytes of the child rather than the child value.
-     *
-     * @param ser           the serializer buffer
-     * @param child         the child value whose type is to be encoded
-     * @param childDataType the data type of the child
-     * @throws NoSuchTypeException if the child type is not found
-     */
-    protected void encodeChildType(final SerializerBuffer ser,
-                                   final AbstractCLValue<?, ?> child,
-                                   final CLTypeData childDataType) throws NoSuchTypeException {
-        if (child instanceof AbstractCLValueWithChildren) {
-            child.encodeType(ser);
-        } else {
-            // If there are no AbstractCLValueWithChildren as children we just need a simple tag
-            byte element0TypeTag = childDataType.getSerializationTag();
-            ser.writeU8(element0TypeTag);
-        }
-    }
-
-    public void populateChildTypes(final DeserializerBuffer dser) {
-
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/AbstractCLValueWithChildren.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/AbstractCLValueWithChildren.java
@@ -32,8 +32,7 @@ public abstract class AbstractCLValueWithChildren<T, P extends AbstractCLTypeWit
     @SneakyThrows({ValueDeserializationException.class})
     protected void childTypesSet() {
         if (!getBytes().isEmpty()) {
-            DeserializerBuffer deser = new DeserializerBuffer(this.getBytes());
-            this.deserialize(deser);
+            this.deserialize(new DeserializerBuffer(this.getBytes()));
         }
     }
 
@@ -50,14 +49,13 @@ public abstract class AbstractCLValueWithChildren<T, P extends AbstractCLTypeWit
         this.setBytes(bytes);
 
         if (!getClType().getChildTypes().isEmpty() && getClType().isDeserializable()) {
-            DeserializerBuffer deser = new DeserializerBuffer(this.getBytes());
-            this.deserialize(deser);
+            this.deserialize(new DeserializerBuffer(this.getBytes()));
         }
     }
 
     protected void encodeType(final SerializerBuffer ser) throws NoSuchTypeException {
-      super.encodeType(ser);
-      encodeChildTypes(ser);
+        super.encodeType(ser);
+        encodeChildTypes(ser);
     }
 
     protected abstract void encodeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException;
@@ -81,5 +79,9 @@ public abstract class AbstractCLValueWithChildren<T, P extends AbstractCLTypeWit
             byte element0TypeTag = childDataType.getSerializationTag();
             ser.writeU8(element0TypeTag);
         }
+    }
+
+    public void populateChildTypes(final DeserializerBuffer dser) {
+
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueByteArray.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueByteArray.java
@@ -1,7 +1,6 @@
 package com.casper.sdk.model.clvalue;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.CLTypeByteArray;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.oak3.sbs4j.DeserializerBuffer;
@@ -40,12 +39,6 @@ public class CLValueByteArray extends AbstractCLValue<byte[], CLTypeByteArray> {
     protected void serializeValue(final SerializerBuffer ser) throws ValueSerializationException {
         ser.writeByteArray(this.getValue());
         this.setBytes(Hex.toHexString(getValue()));
-    }
-
-    @Override
-    protected void encodeType(final SerializerBuffer ser) throws NoSuchTypeException {
-        super.encodeType(ser);
-        ser.writeI32(this.getClType().getLength());
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueList.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueList.java
@@ -1,6 +1,5 @@
 package com.casper.sdk.model.clvalue;
 
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
 import com.casper.sdk.model.clvalue.cltype.CLTypeList;
@@ -67,11 +66,6 @@ public class CLValueList extends AbstractCLValueWithChildren<List<? extends Abst
         this.setBytes(Hex.toHexString(bytes));
     }
 
-    @Override
-    protected void encodeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException {
-        final byte val = (getClType().getListType().getClTypeData().getSerializationTag());
-        ser.writeU8(val);
-    }
 
     @Override
     public void deserializeCustom(final DeserializerBuffer deser) throws Exception {

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueMap.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueMap.java
@@ -1,8 +1,5 @@
 package com.casper.sdk.model.clvalue;
 
-import com.casper.sdk.exception.DynamicInstanceException;
-import com.casper.sdk.exception.NoSuchTypeException;
-import com.casper.sdk.model.clvalue.cltype.AbstractCLType;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
 import com.casper.sdk.model.clvalue.cltype.CLTypeMap;
@@ -11,7 +8,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
 import dev.oak3.sbs4j.SerializerBuffer;
-import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import dev.oak3.sbs4j.exception.ValueSerializationException;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -73,21 +69,6 @@ public class CLValueMap extends
         this.setBytes(Hex.toHexString(bytes));
     }
 
-    @Override
-    protected void encodeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException {
-
-        final byte keyTypeTag = (getClType().getKeyValueTypes().getKeyType().getClTypeData().getSerializationTag());
-        ser.writeU8(keyTypeTag);
-
-        final Map<? extends AbstractCLValue<?, ?>, ? extends AbstractCLValue<?, ?>> value = this.getValue();
-        final CLTypeData clTypeData = getClType().getKeyValueTypes().getValueType().getClTypeData();
-        if (!value.isEmpty()) {
-            encodeChildType(ser, value.values().iterator().next(), clTypeData);
-        } else {
-            final byte valueTypeTag = (clTypeData.getSerializationTag());
-            ser.writeU8(valueTypeTag);
-        }
-    }
 
     @Override
     public void deserializeCustom(final DeserializerBuffer deser) throws Exception {

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueMap.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueMap.java
@@ -1,6 +1,8 @@
 package com.casper.sdk.model.clvalue;
 
+import com.casper.sdk.exception.DynamicInstanceException;
 import com.casper.sdk.exception.NoSuchTypeException;
+import com.casper.sdk.model.clvalue.cltype.AbstractCLType;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
 import com.casper.sdk.model.clvalue.cltype.CLTypeMap;
@@ -9,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
 import dev.oak3.sbs4j.SerializerBuffer;
+import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import dev.oak3.sbs4j.exception.ValueSerializationException;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -88,6 +91,10 @@ public class CLValueMap extends
 
     @Override
     public void deserializeCustom(final DeserializerBuffer deser) throws Exception {
+        if (this.clType.getChildTypes().isEmpty()) {
+            this.clType.deserializeChildTypes(deser);
+        }
+
         final CLTypeData keyType = clType.getKeyValueTypes().getKeyType().getClTypeData();
         final CLTypeData valType = clType.getKeyValueTypes().getValueType().getClTypeData();
 
@@ -122,6 +129,7 @@ public class CLValueMap extends
         setValue(map);
     }
 
+
     @Override
     @JsonIgnore
     protected void setChildTypes(final Map<? extends AbstractCLValue<?, ?>, ? extends AbstractCLValue<?, ?>> value) {
@@ -134,8 +142,8 @@ public class CLValueMap extends
     }
 
     // This needed to be customized to ensure equality is being checked correctly.
-    // The java Map equals method tries to get the "other" map entry's value by using "this" key object,
-    // which then fails to find the object since they are "different" and returns always null.
+// The java Map equals method tries to get the "other" map entry's value by using "this" key object,
+// which then fails to find the object since they are "different" and returns always null.
     @Override
     public boolean equals(final Object o) {
         if (o == this) return true;

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueMap.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueMap.java
@@ -122,9 +122,14 @@ public class CLValueMap extends
         }
     }
 
-    // This needed to be customized to ensure equality is being checked correctly.
-// The java Map equals method tries to get the "other" map entry's value by using "this" key object,
-// which then fails to find the object since they are "different" and returns always null.
+    /**
+     * This needed to be customized to ensure equality is being checked correctly.
+     * The java Map equals method tries to get the "other" map entry's value by using "this" key object,
+     * which then fails to find the object since they are "different" and returns always null.
+     *
+     * @param o the object to compare
+     * @return true if the objects are equal, false otherwise
+     */
     @Override
     public boolean equals(final Object o) {
         if (o == this) return true;
@@ -175,6 +180,15 @@ public class CLValueMap extends
 
     @Override
     public String toString() {
-        return getValue() != null ? getValue().entrySet().stream().map(entry -> entry.getKey().toString() + "=" + entry.getValue().toString()).collect(Collectors.joining(", ")) : null;
+        if (getValue() == null) {
+            return null;
+        } else {
+            return getValue()
+                    .entrySet()
+                    .stream()
+                    .map(entry ->
+                            entry.getKey().toString() + "=" + entry.getValue().toString()).collect(Collectors.joining(", ")
+                    );
+        }
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueMap.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueMap.java
@@ -76,8 +76,14 @@ public class CLValueMap extends
         final byte keyTypeTag = (getClType().getKeyValueTypes().getKeyType().getClTypeData().getSerializationTag());
         ser.writeU8(keyTypeTag);
 
-        final byte valueTypeTag = (getClType().getKeyValueTypes().getValueType().getClTypeData().getSerializationTag());
-        ser.writeU8(valueTypeTag);
+        final Map<? extends AbstractCLValue<?, ?>, ? extends AbstractCLValue<?, ?>> value = this.getValue();
+        final CLTypeData clTypeData = getClType().getKeyValueTypes().getValueType().getClTypeData();
+        if (!value.isEmpty()) {
+            encodeChildType(ser, value.values().iterator().next(), clTypeData);
+        } else {
+            final byte valueTypeTag = (clTypeData.getSerializationTag());
+            ser.writeU8(valueTypeTag);
+        }
     }
 
     @Override
@@ -180,6 +186,6 @@ public class CLValueMap extends
 
     @Override
     public String toString() {
-        return getValue() != null ? getValue().keySet().stream().map(key -> key.getValue().toString() + "=" + key.getValue().toString()).collect(Collectors.joining(", ")) : null;
+        return getValue() != null ? getValue().entrySet().stream().map(entry -> entry.getKey().toString() + "=" + entry.getValue().toString()).collect(Collectors.joining(", ")) : null;
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueOption.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueOption.java
@@ -1,6 +1,5 @@
 package com.casper.sdk.model.clvalue;
 
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.*;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
@@ -90,14 +89,6 @@ public class CLValueOption extends AbstractCLValueWithChildren<Optional<Abstract
         }
 
         setValue(Optional.of(child));
-    }
-
-    @Override
-    protected void encodeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException {
-        final Optional<AbstractCLValue<?, ?>> child = getValue();
-        if (child.isPresent()) {
-            encodeChildType(ser, child.get(), this.getClType().getOptionType().getClTypeData());
-        }
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple1.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple1.java
@@ -1,6 +1,5 @@
 package com.casper.sdk.model.clvalue;
 
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
 import com.casper.sdk.model.clvalue.cltype.CLTypeTuple1;
@@ -54,11 +53,6 @@ public class CLValueTuple1 extends AbstractCLValueWithChildren<Unit<? extends Ab
         final byte[] bytes = serVal.toByteArray();
         ser.writeByteArray(bytes);
         this.setBytes(Hex.toHexString(bytes));
-    }
-
-    @Override
-    protected void encodeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException {
-        encodeChildType(ser, this.getValue().getValue0(), getClType().getChildClTypeData(0));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple2.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple2.java
@@ -1,6 +1,5 @@
 package com.casper.sdk.model.clvalue;
 
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
 import com.casper.sdk.model.clvalue.cltype.CLTypeTuple2;
@@ -58,13 +57,6 @@ public class CLValueTuple2
         this.setBytes(Hex.toHexString(bytes));
 
     }
-
-    @Override
-    protected void encodeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException {
-        encodeChildType(ser, this.getValue().getValue0(), getClType().getChildClTypeData(0));
-        encodeChildType(ser, this.getValue().getValue1(), getClType().getChildClTypeData(1));
-    }
-
 
     @Override
     public void deserializeCustom(final DeserializerBuffer deser) throws Exception {

--- a/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple3.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/CLValueTuple3.java
@@ -1,6 +1,5 @@
 package com.casper.sdk.model.clvalue;
 
-import com.casper.sdk.exception.NoSuchTypeException;
 import com.casper.sdk.model.clvalue.cltype.AbstractCLTypeWithChildren;
 import com.casper.sdk.model.clvalue.cltype.CLTypeData;
 import com.casper.sdk.model.clvalue.cltype.CLTypeTuple3;
@@ -57,13 +56,6 @@ public class CLValueTuple3 extends
         final byte[] bytes = serVal.toByteArray();
         ser.writeByteArray(bytes);
         this.setBytes(Hex.toHexString(bytes));
-    }
-
-    @Override
-    protected void encodeChildTypes(SerializerBuffer ser) throws NoSuchTypeException {
-        encodeChildType(ser, this.getValue().getValue0(), getClType().getChildClTypeData(0));
-        encodeChildType(ser, this.getValue().getValue1(), getClType().getChildClTypeData(1));
-        encodeChildType(ser, this.getValue().getValue2(), getClType().getChildClTypeData(2));
     }
 
     @Override

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/AbstractCLType.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/AbstractCLType.java
@@ -5,6 +5,7 @@ import com.casper.sdk.jackson.resolver.CLTypeResolver;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonTypeResolver;
+import dev.oak3.sbs4j.SerializerBuffer;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -67,7 +68,7 @@ public abstract class AbstractCLType {
     }
 
     /**
-     * Indicates if the CLType does not contains and 'Any', or other un-deserializable child type from bytes. The reason
+     * Indicates if the CLType does not contain an 'Any', or other un-deserializable child type from bytes. The reason
      * for this is the 'Any' type does not provide a length for its bytes. This type information is obtained from the
      * JSON metadata.
      *
@@ -76,4 +77,15 @@ public abstract class AbstractCLType {
      */
     @JsonIgnore
     public abstract boolean isDeserializable();
+
+
+    /**
+     * Serializes the type to the provided buffer
+     *
+     * @param ser the buffer to serialize to
+     * @throws NoSuchTypeException if the type is not supported
+     */
+    public void serialize(final SerializerBuffer ser) throws NoSuchTypeException {
+        ser.writeU8(getClTypeData().getSerializationTag());
+    }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/AbstractCLTypeBasic.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/AbstractCLTypeBasic.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
  */
 @NoArgsConstructor
 public abstract class AbstractCLTypeBasic extends AbstractCLType {
-    protected AbstractCLTypeBasic(String typeName) {
+    protected AbstractCLTypeBasic(final String typeName) {
         if (!this.getTypeName().equals(typeName)) {
             throw new IllegalArgumentException(
                     String.format("%s is an invalid type for %s", getClass().getSimpleName(), typeName));

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/AbstractCLTypeWithChildren.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/AbstractCLTypeWithChildren.java
@@ -1,7 +1,10 @@
 package com.casper.sdk.model.clvalue.cltype;
 
+import com.casper.sdk.exception.DynamicInstanceException;
 import com.casper.sdk.exception.NoSuchTypeException;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import dev.oak3.sbs4j.DeserializerBuffer;
+import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -27,10 +30,9 @@ public abstract class AbstractCLTypeWithChildren extends AbstractCLType {
 
     @JsonIgnore
     private List<AbstractCLType> childTypes = new ArrayList<>();
-
     private List<Object> childTypeObjects;
 
-    protected void setChildTypeObjects(List<Object> childTypeObjects)
+    protected void setChildTypeObjects(final List<Object> childTypeObjects)
             throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
             NoSuchMethodException, SecurityException, NoSuchTypeException {
         this.childTypeObjects = childTypeObjects;
@@ -55,7 +57,7 @@ public abstract class AbstractCLTypeWithChildren extends AbstractCLType {
     }
 
     @JsonIgnore
-    public CLTypeData getChildClTypeData(int index) throws NoSuchTypeException {
+    public CLTypeData getChildClTypeData(final int index) throws NoSuchTypeException {
         return CLTypeData.getTypeByName(getChildTypes().get(index).getTypeName());
     }
 
@@ -64,7 +66,7 @@ public abstract class AbstractCLTypeWithChildren extends AbstractCLType {
         return getChildTypes().stream().allMatch(AbstractCLType::isDeserializable);
     }
 
-    protected void loadCLTypes(List<Object> childTypeObjects)
+    protected void loadCLTypes(final List<Object> childTypeObjects)
             throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
             NoSuchMethodException, SecurityException, NoSuchTypeException {
         childTypes.clear();
@@ -97,4 +99,11 @@ public abstract class AbstractCLTypeWithChildren extends AbstractCLType {
             }
         }
     }
+
+    /**
+     * Update the child types from the deserializer buffer.
+     *
+     * @param deser the deserializer buffer
+     */
+    public abstract void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException;
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/AbstractCLTypeWithChildren.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/AbstractCLTypeWithChildren.java
@@ -4,6 +4,7 @@ import com.casper.sdk.exception.DynamicInstanceException;
 import com.casper.sdk.exception.NoSuchTypeException;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import dev.oak3.sbs4j.DeserializerBuffer;
+import dev.oak3.sbs4j.SerializerBuffer;
 import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -100,10 +101,23 @@ public abstract class AbstractCLTypeWithChildren extends AbstractCLType {
         }
     }
 
+    @Override
+    public void serialize(final SerializerBuffer ser) throws NoSuchTypeException {
+        super.serialize(ser);
+        serializeChildTypes(ser);
+    }
+
     /**
      * Updates the child types from the deserializer buffer.
      *
      * @param deser the deserializer buffer
      */
     public abstract void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException;
+
+    /**
+     * Writes the child types to the serialization buffer.
+     *
+     * @param ser the serialization buffer
+     */
+    protected abstract void serializeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException;
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/AbstractCLTypeWithChildren.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/AbstractCLTypeWithChildren.java
@@ -112,7 +112,8 @@ public abstract class AbstractCLTypeWithChildren extends AbstractCLType {
      *
      * @param deser the deserializer buffer
      */
-    public abstract void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException;
+    public abstract void deserializeChildTypes(final DeserializerBuffer deser)
+            throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException;
 
     /**
      * Writes the child types to the serialization buffer.
@@ -120,4 +121,17 @@ public abstract class AbstractCLTypeWithChildren extends AbstractCLType {
      * @param ser the serialization buffer
      */
     protected abstract void serializeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException;
+
+    protected AbstractCLType deserializeChildType(final DeserializerBuffer deser)
+            throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
+        final int childTypeTag = deser.readU8();
+        final CLTypeData childType = CLTypeData.getTypeBySerializationTag((byte) childTypeTag);
+        final AbstractCLType clChildType = CLTypeData.createCLTypeFromCLTypeName(childType.getClTypeName());
+
+        if (clChildType instanceof AbstractCLTypeWithChildren) {
+            ((AbstractCLTypeWithChildren) clChildType).deserializeChildTypes(deser);
+        }
+
+        return clChildType;
+    }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/AbstractCLTypeWithChildren.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/AbstractCLTypeWithChildren.java
@@ -78,7 +78,7 @@ public abstract class AbstractCLTypeWithChildren extends AbstractCLType {
         }
     }
 
-    private void addChildType(Object childTypeObject, List<AbstractCLType> parent)
+    private void addChildType(final Object childTypeObject, final List<AbstractCLType> parent)
             throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
             NoSuchMethodException, SecurityException, NoSuchTypeException {
         if (childTypeObject instanceof String) {
@@ -101,7 +101,7 @@ public abstract class AbstractCLTypeWithChildren extends AbstractCLType {
     }
 
     /**
-     * Update the child types from the deserializer buffer.
+     * Updates the child types from the deserializer buffer.
      *
      * @param deser the deserializer buffer
      */

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeAny.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeAny.java
@@ -20,7 +20,7 @@ public class CLTypeAny extends AbstractCLTypeBasic {
     private final String typeName = AbstractCLType.ANY;
 
     @JsonCreator
-    protected CLTypeAny(String typeName) {
+    protected CLTypeAny(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeBool.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeBool.java
@@ -20,7 +20,7 @@ public class CLTypeBool extends AbstractCLTypeBasic {
     private final String typeName = AbstractCLType.BOOL;
 
     @JsonCreator
-    protected CLTypeBool(String typeName) {
+    protected CLTypeBool(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeByteArray.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeByteArray.java
@@ -1,6 +1,8 @@
 package com.casper.sdk.model.clvalue.cltype;
 
+import com.casper.sdk.exception.NoSuchTypeException;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.oak3.sbs4j.SerializerBuffer;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -25,5 +27,11 @@ public class CLTypeByteArray extends AbstractCLType {
     @Override
     public boolean isDeserializable() {
         return true;
+    }
+
+    @Override
+    public void serialize(final SerializerBuffer ser) throws NoSuchTypeException {
+        super.serialize(ser);
+        ser.writeI32(getLength());
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeData.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeData.java
@@ -59,7 +59,7 @@ public enum CLTypeData {
      * @return the requested {@link CLTypeData}
      * @throws NoSuchTypeException raised when the clType is not valid/found
      */
-    public static CLTypeData getTypeBySerializationTag(byte serializationTag) throws NoSuchTypeException {
+    public static CLTypeData getTypeBySerializationTag(final byte serializationTag) throws NoSuchTypeException {
         for (CLTypeData clType : values()) {
             if (clType.serializationTag == serializationTag) {
                 return clType;

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeI32.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeI32.java
@@ -20,7 +20,7 @@ public class CLTypeI32 extends AbstractCLTypeBasic {
     private final String typeName = I32;
 
     @JsonCreator
-    protected CLTypeI32(String typeName) {
+    protected CLTypeI32(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeI64.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeI64.java
@@ -20,7 +20,7 @@ public class CLTypeI64 extends AbstractCLTypeBasic {
     private final String typeName = I64;
 
     @JsonCreator
-    protected CLTypeI64(String typeName) {
+    protected CLTypeI64(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeKey.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeKey.java
@@ -20,7 +20,7 @@ public class CLTypeKey extends AbstractCLTypeBasic {
     private final String typeName = AbstractCLType.KEY;
 
     @JsonCreator
-    protected CLTypeKey(String typeName) {
+    protected CLTypeKey(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeList.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeList.java
@@ -76,15 +76,8 @@ public class CLTypeList extends AbstractCLTypeWithChildren {
     }
 
     @Override
-    public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
-        final int childTypeTag = deser.readU8();
-        final CLTypeData childType = CLTypeData.getTypeBySerializationTag((byte) childTypeTag);
-        final AbstractCLType clChildType = CLTypeData.createCLTypeFromCLTypeName(childType.getClTypeName());
-
-        if (clChildType instanceof AbstractCLTypeWithChildren) {
-            ((AbstractCLTypeWithChildren) clChildType).deserializeChildTypes(deser);
-        }
-
-        setListType(clChildType);
+    public void deserializeChildTypes(final DeserializerBuffer deser)
+            throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
+        setListType(deserializeChildType(deser));
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeList.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeList.java
@@ -1,9 +1,13 @@
 package com.casper.sdk.model.clvalue.cltype;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
+import com.casper.sdk.exception.DynamicInstanceException;
+import com.casper.sdk.exception.NoSuchTypeException;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import dev.oak3.sbs4j.DeserializerBuffer;
+import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -32,7 +36,7 @@ public class CLTypeList extends AbstractCLTypeWithChildren {
 
     @JsonSetter(AbstractCLType.LIST)
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonValue(AbstractCLType clType) {
+    protected void setJsonValue(final AbstractCLType clType) {
         getChildTypes().add(clType);
     }
 
@@ -46,7 +50,7 @@ public class CLTypeList extends AbstractCLTypeWithChildren {
     }
 
     @JsonIgnore
-    public void setListType(AbstractCLType listType) {
+    public void setListType(final AbstractCLType listType) {
         getChildTypes().clear();
         getChildTypes().add(listType);
     }
@@ -61,5 +65,10 @@ public class CLTypeList extends AbstractCLTypeWithChildren {
                 return childType.isDeserializable();
             }
         });
+    }
+
+    @Override
+    public void deserializeChildTypes(DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
+        // FIXME: 2021/10/20
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeMap.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeMap.java
@@ -112,21 +112,11 @@ public class CLTypeMap extends AbstractCLTypeWithChildren {
     }
 
     @Override
-    public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
-
+    public void deserializeChildTypes(final DeserializerBuffer deser)
+            throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
         // read child types
-        final int keyTypeTag = deser.readU8();
-        final int valueTypeTag = deser.readU8();
-
-        final CLTypeData keyType = CLTypeData.getTypeBySerializationTag((byte) keyTypeTag);
-        final CLTypeData valueType = CLTypeData.getTypeBySerializationTag((byte) valueTypeTag);
-        final AbstractCLType clTypeKey = CLTypeData.createCLTypeFromCLTypeName(keyType.getClTypeName());
-        final AbstractCLType clTypeValue = CLTypeData.createCLTypeFromCLTypeName(valueType.getClTypeName());
-
-        if (clTypeValue instanceof AbstractCLTypeWithChildren) {
-            ((AbstractCLTypeWithChildren) clTypeValue).deserializeChildTypes(deser);
-        }
-
+        final AbstractCLType clTypeKey = deserializeChildType(deser);
+        final AbstractCLType clTypeValue = deserializeChildType(deser);
         setKeyValueTypes(new CLTypeMap.CLTypeMapEntryType(clTypeKey, clTypeValue));
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeMap.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeMap.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
+import dev.oak3.sbs4j.SerializerBuffer;
 import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.*;
 
@@ -105,6 +106,12 @@ public class CLTypeMap extends AbstractCLTypeWithChildren {
     }
 
     @Override
+    public void serializeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException {
+        getKeyValueTypes().getKeyType().serialize(ser);
+        getKeyValueTypes().getValueType().serialize(ser);
+    }
+
+    @Override
     public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
 
         // read child types
@@ -114,7 +121,7 @@ public class CLTypeMap extends AbstractCLTypeWithChildren {
         final CLTypeData keyType = CLTypeData.getTypeBySerializationTag((byte) keyTypeTag);
         final CLTypeData valueType = CLTypeData.getTypeBySerializationTag((byte) valueTypeTag);
         final AbstractCLType clTypeKey = CLTypeData.createCLTypeFromCLTypeName(keyType.getClTypeName());
-        AbstractCLType clTypeValue = CLTypeData.createCLTypeFromCLTypeName(valueType.getClTypeName());
+        final AbstractCLType clTypeValue = CLTypeData.createCLTypeFromCLTypeName(valueType.getClTypeName());
 
         if (clTypeValue instanceof AbstractCLTypeWithChildren) {
             ((AbstractCLTypeWithChildren) clTypeValue).deserializeChildTypes(deser);

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeOption.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeOption.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import dev.oak3.sbs4j.DeserializerBuffer;
+import dev.oak3.sbs4j.SerializerBuffer;
 import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -63,7 +64,12 @@ public class CLTypeOption extends AbstractCLTypeWithChildren {
     }
 
     @Override
+    public void serializeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException {
+        getOptionType().serialize(ser);
+    }
+
+    @Override
     public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
-        // FIXME: 2021/10/20
+        // FIXME
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeOption.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeOption.java
@@ -70,6 +70,6 @@ public class CLTypeOption extends AbstractCLTypeWithChildren {
 
     @Override
     public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
-        // FIXME
+        setOptionType(deserializeChildType(deser));
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeOption.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeOption.java
@@ -1,9 +1,13 @@
 package com.casper.sdk.model.clvalue.cltype;
 
 import com.casper.sdk.annotation.ExcludeFromJacocoGeneratedReport;
+import com.casper.sdk.exception.DynamicInstanceException;
+import com.casper.sdk.exception.NoSuchTypeException;
 import com.fasterxml.jackson.annotation.JsonGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonSetter;
+import dev.oak3.sbs4j.DeserializerBuffer;
+import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,7 +38,7 @@ public class CLTypeOption extends AbstractCLTypeWithChildren {
 
     @JsonSetter(OPTION)
     @ExcludeFromJacocoGeneratedReport
-    protected void setJsonClType(AbstractCLType clType) {
+    protected void setJsonClType(final AbstractCLType clType) {
         getChildTypes().add(clType);
     }
 
@@ -48,7 +52,7 @@ public class CLTypeOption extends AbstractCLTypeWithChildren {
     }
 
     @JsonIgnore
-    public void setOptionType(AbstractCLType listType) {
+    public void setOptionType(final AbstractCLType listType) {
         getChildTypes().clear();
         getChildTypes().add(listType);
     }
@@ -56,5 +60,10 @@ public class CLTypeOption extends AbstractCLTypeWithChildren {
     @Override
     public boolean isDeserializable() {
         return getOptionType().isDeserializable();
+    }
+
+    @Override
+    public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
+        // FIXME: 2021/10/20
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypePublicKey.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypePublicKey.java
@@ -20,7 +20,7 @@ public class CLTypePublicKey extends AbstractCLTypeBasic {
     private final String typeName = PUBLIC_KEY;
 
     @JsonCreator
-    protected CLTypePublicKey(String typeName) {
+    protected CLTypePublicKey(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeResult.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeResult.java
@@ -46,7 +46,7 @@ public class CLTypeResult extends AbstractCLType {
 
         @JsonSetter("ok")
         @ExcludeFromJacocoGeneratedReport
-        protected void setJsonKey(AbstractCLType clType) {
+        protected void setJsonKey(final AbstractCLType clType) {
             this.okClType = clType;
         }
 
@@ -62,7 +62,7 @@ public class CLTypeResult extends AbstractCLType {
 
         @JsonSetter("err")
         @ExcludeFromJacocoGeneratedReport
-        protected void setJsonValue(AbstractCLType clType) {
+        protected void setJsonValue(final AbstractCLType clType) {
             this.errClType = clType;
         }
 

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeString.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeString.java
@@ -20,7 +20,7 @@ public class CLTypeString extends AbstractCLTypeBasic {
     private final String typeName = STRING;
 
     @JsonCreator
-    protected CLTypeString(String typeName) {
+    protected CLTypeString(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple1.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple1.java
@@ -1,7 +1,10 @@
 package com.casper.sdk.model.clvalue.cltype;
 
+import com.casper.sdk.exception.DynamicInstanceException;
 import com.casper.sdk.exception.NoSuchTypeException;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.oak3.sbs4j.DeserializerBuffer;
+import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -23,7 +26,7 @@ public class CLTypeTuple1 extends AbstractCLTypeWithChildren {
 
     @Override
     @JsonProperty(TUPLE1)
-    protected void setChildTypeObjects(List<Object> childTypeObjects)
+    protected void setChildTypeObjects(final List<Object> childTypeObjects)
             throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
             NoSuchMethodException, SecurityException, NoSuchTypeException {
         super.setChildTypeObjects(childTypeObjects);
@@ -33,5 +36,10 @@ public class CLTypeTuple1 extends AbstractCLTypeWithChildren {
     @JsonProperty(TUPLE1)
     protected List<Object> getChildTypeObjects() {
         return super.getChildTypeObjects();
+    }
+
+    @Override
+    public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
+        // FIXME: 2021/10/20
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple1.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple1.java
@@ -4,6 +4,7 @@ import com.casper.sdk.exception.DynamicInstanceException;
 import com.casper.sdk.exception.NoSuchTypeException;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.oak3.sbs4j.DeserializerBuffer;
+import dev.oak3.sbs4j.SerializerBuffer;
 import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -39,7 +40,14 @@ public class CLTypeTuple1 extends AbstractCLTypeWithChildren {
     }
 
     @Override
+    public void serializeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException {
+        if (!getChildTypes().isEmpty()) {
+            getChildTypes().get(0).serialize(ser);
+        }
+    }
+
+    @Override
     public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
-        // FIXME: 2021/10/20
+        // FIXME
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple1.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple1.java
@@ -47,7 +47,8 @@ public class CLTypeTuple1 extends AbstractCLTypeWithChildren {
     }
 
     @Override
-    public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
-        // FIXME
+    public void deserializeChildTypes(final DeserializerBuffer deser)
+            throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
+        getChildTypes().add(deserializeChildType(deser));
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple2.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple2.java
@@ -41,7 +41,7 @@ public class CLTypeTuple2 extends AbstractCLTypeWithChildren {
     }
 
     @Override
-    public void serializeChildTypes(SerializerBuffer ser) throws NoSuchTypeException {
+    public void serializeChildTypes(final SerializerBuffer ser) throws NoSuchTypeException {
 
         if (getChildTypes().size() >= 2) {
             getChildTypes().get(0).serialize(ser);
@@ -55,6 +55,4 @@ public class CLTypeTuple2 extends AbstractCLTypeWithChildren {
         getChildTypes().add(deserializeChildType(deser));
         getChildTypes().add(deserializeChildType(deser));
     }
-
-
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple2.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple2.java
@@ -50,7 +50,11 @@ public class CLTypeTuple2 extends AbstractCLTypeWithChildren {
     }
 
     @Override
-    public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
-        // FIXME
+    public void deserializeChildTypes(final DeserializerBuffer deser)
+            throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
+        getChildTypes().add(deserializeChildType(deser));
+        getChildTypes().add(deserializeChildType(deser));
     }
+
+
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple2.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple2.java
@@ -4,6 +4,7 @@ import com.casper.sdk.exception.DynamicInstanceException;
 import com.casper.sdk.exception.NoSuchTypeException;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.oak3.sbs4j.DeserializerBuffer;
+import dev.oak3.sbs4j.SerializerBuffer;
 import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -22,6 +23,7 @@ import java.util.List;
 @Getter
 @EqualsAndHashCode(callSuper = true, of = {"typeName"})
 public class CLTypeTuple2 extends AbstractCLTypeWithChildren {
+
     private final String typeName = AbstractCLType.TUPLE2;
 
     @Override
@@ -39,7 +41,16 @@ public class CLTypeTuple2 extends AbstractCLTypeWithChildren {
     }
 
     @Override
+    public void serializeChildTypes(SerializerBuffer ser) throws NoSuchTypeException {
+
+        if (getChildTypes().size() >= 2) {
+            getChildTypes().get(0).serialize(ser);
+            getChildTypes().get(1).serialize(ser);
+        }
+    }
+
+    @Override
     public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
-        // FIXME: 2021/10/20
+        // FIXME
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple2.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple2.java
@@ -1,7 +1,10 @@
 package com.casper.sdk.model.clvalue.cltype;
 
+import com.casper.sdk.exception.DynamicInstanceException;
 import com.casper.sdk.exception.NoSuchTypeException;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.oak3.sbs4j.DeserializerBuffer;
+import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -23,7 +26,7 @@ public class CLTypeTuple2 extends AbstractCLTypeWithChildren {
 
     @Override
     @JsonProperty(AbstractCLType.TUPLE2)
-    protected void setChildTypeObjects(List<Object> childTypeObjects)
+    protected void setChildTypeObjects(final List<Object> childTypeObjects)
             throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
             NoSuchMethodException, SecurityException, NoSuchTypeException {
         super.setChildTypeObjects(childTypeObjects);
@@ -33,5 +36,10 @@ public class CLTypeTuple2 extends AbstractCLTypeWithChildren {
     @JsonProperty(AbstractCLType.TUPLE2)
     protected List<Object> getChildTypeObjects() {
         return super.getChildTypeObjects();
+    }
+
+    @Override
+    public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
+        // FIXME: 2021/10/20
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple3.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple3.java
@@ -53,5 +53,6 @@ public class CLTypeTuple3 extends AbstractCLTypeWithChildren {
             throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
         getChildTypes().add(deserializeChildType(deser));
         getChildTypes().add(deserializeChildType(deser));
+        getChildTypes().add(deserializeChildType(deser));
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple3.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple3.java
@@ -1,7 +1,10 @@
 package com.casper.sdk.model.clvalue.cltype;
 
+import com.casper.sdk.exception.DynamicInstanceException;
 import com.casper.sdk.exception.NoSuchTypeException;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import dev.oak3.sbs4j.DeserializerBuffer;
+import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
@@ -23,7 +26,7 @@ public class CLTypeTuple3 extends AbstractCLTypeWithChildren {
 
     @Override
     @JsonProperty(AbstractCLType.TUPLE3)
-    protected void setChildTypeObjects(List<Object> childTypeObjects)
+    protected void setChildTypeObjects(final List<Object> childTypeObjects)
             throws InstantiationException, IllegalAccessException, IllegalArgumentException, InvocationTargetException,
             NoSuchMethodException, SecurityException, NoSuchTypeException {
         super.setChildTypeObjects(childTypeObjects);
@@ -33,5 +36,10 @@ public class CLTypeTuple3 extends AbstractCLTypeWithChildren {
     @JsonProperty(AbstractCLType.TUPLE3)
     protected List<Object> getChildTypeObjects() {
         return super.getChildTypeObjects();
+    }
+
+    @Override
+    public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
+        // FIXME: 2021/10/20
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple3.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple3.java
@@ -49,7 +49,9 @@ public class CLTypeTuple3 extends AbstractCLTypeWithChildren {
     }
 
     @Override
-    public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
-        // FIXME
+    public void deserializeChildTypes(final DeserializerBuffer deser)
+            throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
+        getChildTypes().add(deserializeChildType(deser));
+        getChildTypes().add(deserializeChildType(deser));
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple3.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeTuple3.java
@@ -4,6 +4,7 @@ import com.casper.sdk.exception.DynamicInstanceException;
 import com.casper.sdk.exception.NoSuchTypeException;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.oak3.sbs4j.DeserializerBuffer;
+import dev.oak3.sbs4j.SerializerBuffer;
 import dev.oak3.sbs4j.exception.ValueDeserializationException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -38,8 +39,17 @@ public class CLTypeTuple3 extends AbstractCLTypeWithChildren {
         return super.getChildTypeObjects();
     }
 
+    public void serializeChildTypes(SerializerBuffer ser) throws NoSuchTypeException {
+
+        if (getChildTypes().size() >= 3) {
+            getChildTypes().get(0).serialize(ser);
+            getChildTypes().get(1).serialize(ser);
+            getChildTypes().get(2).serialize(ser);
+        }
+    }
+
     @Override
     public void deserializeChildTypes(final DeserializerBuffer deser) throws ValueDeserializationException, NoSuchTypeException, DynamicInstanceException {
-        // FIXME: 2021/10/20
+        // FIXME
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeU128.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeU128.java
@@ -21,7 +21,7 @@ public class CLTypeU128 extends AbstractCLTypeBasic {
     private final String typeName = U128;
 
     @JsonCreator
-    protected CLTypeU128(String typeName) {
+    protected CLTypeU128(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeU256.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeU256.java
@@ -21,7 +21,7 @@ public class CLTypeU256 extends AbstractCLTypeBasic {
     private final String typeName = U256;
 
     @JsonCreator
-    protected CLTypeU256(String typeName) {
+    protected CLTypeU256(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeU32.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeU32.java
@@ -20,7 +20,7 @@ public class CLTypeU32 extends AbstractCLTypeBasic {
     private final String typeName = U32;
 
     @JsonCreator
-    protected CLTypeU32(String typeName) {
+    protected CLTypeU32(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeU512.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeU512.java
@@ -21,7 +21,7 @@ public class CLTypeU512 extends AbstractCLTypeBasic {
     private final String typeName = AbstractCLType.U512;
 
     @JsonCreator
-    protected CLTypeU512(String typeName) {
+    protected CLTypeU512(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeU64.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeU64.java
@@ -21,7 +21,7 @@ public class CLTypeU64 extends AbstractCLTypeBasic {
     private final String typeName = U64;
 
     @JsonCreator
-    protected CLTypeU64(String typeName) {
+    protected CLTypeU64(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeU8.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeU8.java
@@ -20,7 +20,7 @@ public class CLTypeU8 extends AbstractCLTypeBasic {
     private final String typeName = AbstractCLType.U8;
 
     @JsonCreator
-    protected CLTypeU8(String typeName) {
+    protected CLTypeU8(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeURef.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeURef.java
@@ -21,7 +21,7 @@ public class CLTypeURef extends AbstractCLTypeBasic {
     private final String typeName = AbstractCLType.UREF;
 
     @JsonCreator
-    protected CLTypeURef(String typeName) {
+    protected CLTypeURef(final String typeName) {
         super(typeName);
     }
 }

--- a/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeUnit.java
+++ b/src/main/java/com/casper/sdk/model/clvalue/cltype/CLTypeUnit.java
@@ -21,7 +21,7 @@ public class CLTypeUnit extends AbstractCLTypeBasic {
     private final String typeName = UNIT;
 
     @JsonCreator
-    protected CLTypeUnit(String typeName) {
+    protected CLTypeUnit(final String typeName) {
         super(typeName);
     }
 }

--- a/src/test/java/com/casper/sdk/model/clvalue/CLValueTests.java
+++ b/src/test/java/com/casper/sdk/model/clvalue/CLValueTests.java
@@ -17,6 +17,7 @@ import org.javatuples.Unit;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -194,6 +195,32 @@ public class CLValueTests {
         outerTuple.serialize(ser, Target.BYTE);
 
         final byte[] expected = {28, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 5, 0, 0, 0, 6, 0, 0, 0, 7, 0, 0, 0, 20, 20, 20, 4, 4, 4, 4, 4, 4, 4};
+
+        assertThat(ser.toByteArray(), is(expected));
+    }
+
+    @Test
+    void nestedMapSerialization() throws Exception {
+
+        Map<CLValueString, CLValueU32> map = new LinkedHashMap<>();
+        map.put(new CLValueString("ONE"), new CLValueU32(1L));
+        final CLValueMap innerMap1 = new CLValueMap(map);
+
+        map = new LinkedHashMap<>();
+        map.put(new CLValueString("TWO"), new CLValueU32(2L));
+        final CLValueMap innerMap2 = new CLValueMap(map);
+
+
+        Map<CLValueString, CLValueMap> map2 = new LinkedHashMap<>();
+        map2.put(new CLValueString("THREE"), innerMap1);
+        map2.put(new CLValueString("FOUR"), innerMap2);
+
+        final CLValueMap outerMap = new CLValueMap(map2);
+
+        final SerializerBuffer ser = new SerializerBuffer();
+        outerMap.serialize(ser, Target.BYTE);
+
+        byte[] expected = {51, 0, 0, 0, 2, 0, 0, 0, 5, 0, 0, 0, 84, 72, 82, 69, 69, 1, 0, 0, 0, 3, 0, 0, 0, 79, 78, 69, 1, 0, 0, 0, 4, 0, 0, 0, 70, 79, 85, 82, 1, 0, 0, 0, 3, 0, 0, 0, 84, 87, 79, 2, 0, 0, 0, 17, 10, 17, 10, 4};
 
         assertThat(ser.toByteArray(), is(expected));
     }

--- a/src/test/java/com/casper/sdk/model/clvalue/CLValueTests.java
+++ b/src/test/java/com/casper/sdk/model/clvalue/CLValueTests.java
@@ -14,9 +14,7 @@ import org.javatuples.Unit;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
@@ -245,37 +243,37 @@ public class CLValueTests {
     void nestedMapDeserialization2() throws Exception {
 
         //  a nested map is created  {1: {11: {111: "ONE_ONE_ONE"}, 12: {121: "ONE_TWO_ONE"}}, 2: {21: {211: "TWO_ONE_ONE"}, 22: {221: "TWO_TWO_ONE"}}}
+        //noinspection rawtypes
+        Map innerMap = new LinkedHashMap<>();
+        innerMap.put(new CLValueU256(BigInteger.valueOf(111L)), new CLValueString("ONE_ONE_ONE"));
+        final CLValueMap innerMap111 = new CLValueMap(innerMap);
 
-        Map map = new LinkedHashMap<>();
-        map.put(new CLValueU256(BigInteger.valueOf(111L)),  new CLValueString("ONE_ONE_ONE"));
-        final CLValueMap innerMap111 = new CLValueMap(map);
+        innerMap = new LinkedHashMap<>();
+        innerMap.put(new CLValueU256(BigInteger.valueOf(121L)), new CLValueString("ONE_TWO_ONE"));
+        final CLValueMap innerMap121 = new CLValueMap(innerMap);
 
-        map = new LinkedHashMap<>();
-        map.put(new CLValueU256(BigInteger.valueOf(121L)),  new CLValueString("ONE_TWO_ONE"));
-        final CLValueMap innerMap121 = new CLValueMap(map);
+        innerMap = new LinkedHashMap<>();
+        innerMap.put(new CLValueU256(BigInteger.valueOf(11L)), innerMap111);
+        innerMap.put(new CLValueU256(BigInteger.valueOf(12L)), innerMap121);
+        final CLValueMap innerMap1 = new CLValueMap(innerMap);
 
-        map = new LinkedHashMap<>();
-        map.put(new CLValueU256(BigInteger.valueOf(11L)), innerMap111);
-        map.put(new CLValueU256(BigInteger.valueOf(12L)), innerMap121);
-        final CLValueMap innerMap1 = new CLValueMap(map);
+        innerMap = new LinkedHashMap<>();
+        innerMap.put(new CLValueU256(BigInteger.valueOf(211L)), new CLValueString("TWO_ONE_ONE"));
+        final CLValueMap innerMap21 = new CLValueMap(innerMap);
 
-        map = new LinkedHashMap<>();
-        map.put(new CLValueU256(BigInteger.valueOf(211L)),  new CLValueString("TWO_ONE_ONE"));
-        final CLValueMap innerMap21 = new CLValueMap(map);
+        innerMap = new LinkedHashMap<>();
+        innerMap.put(new CLValueU256(BigInteger.valueOf(221)), new CLValueString("TWO_TWO_ONE"));
+        final CLValueMap innerMap22 = new CLValueMap(innerMap);
 
-        map = new LinkedHashMap<>();
-        map.put(new CLValueU256(BigInteger.valueOf(221)),  new CLValueString("TWO_TWO_ONE"));
-        final CLValueMap innerMap22 = new CLValueMap(map);
+        innerMap = new LinkedHashMap<>();
+        innerMap.put(new CLValueU256(BigInteger.valueOf(21L)), innerMap21);
+        innerMap.put(new CLValueU256(BigInteger.valueOf(22L)), innerMap22);
+        final CLValueMap innerMap2 = new CLValueMap(innerMap);
 
-        map = new LinkedHashMap<>();
-        map.put(new CLValueU256(BigInteger.valueOf(21L)), innerMap21);
-        map.put(new CLValueU256(BigInteger.valueOf(22L)), innerMap22);
-        final CLValueMap innerMap2 = new CLValueMap(map);
-
-        map = new LinkedHashMap<>();
-        map.put(new CLValueU256(BigInteger.valueOf(1L)), innerMap1);
-        map.put(new CLValueU256(BigInteger.valueOf(2L)), innerMap2);
-        final CLValueMap outerMap = new CLValueMap(map);
+        innerMap = new LinkedHashMap<>();
+        innerMap.put(new CLValueU256(BigInteger.valueOf(1L)), innerMap1);
+        innerMap.put(new CLValueU256(BigInteger.valueOf(2L)), innerMap2);
+        final CLValueMap outerMap = new CLValueMap(innerMap);
 
         final SerializerBuffer ser = new SerializerBuffer();
         outerMap.serialize(ser, Target.BYTE);
@@ -290,5 +288,71 @@ public class CLValueTests {
         assertThat(clValueMap.getBytes(), is(outerMap.getBytes()));
     }
 
+    @Test
+    void nestedListSerialization() throws Exception {
 
+        /*
+        [0] = {u8} 24 [0x18]
+[1] = {u8} 0 [0x0]
+[2] = {u8} 0 [0x0]
+[3] = {u8} 0 [0x0]
+[4] = {u8} 2 [0x2]
+[5] = {u8} 0 [0x0]
+[6] = {u8} 0 [0x0]
+[7] = {u8} 0 [0x0]
+[8] = {u8} 3 [0x3]
+[9] = {u8} 0 [0x0]
+[10] = {u8} 0 [0x0]
+[11] = {u8} 0 [0x0]
+[12] = {u8} 1 [0x1]
+[13] = {u8} 1 [0x1]
+[14] = {u8} 1 [0x1]
+[15] = {u8} 2 [0x2]
+[16] = {u8} 1 [0x1]
+[17] = {u8} 3 [0x3]
+[18] = {u8} 3 [0x3]
+[19] = {u8} 0 [0x0]
+[20] = {u8} 0 [0x0]
+[21] = {u8} 0 [0x0]
+[22] = {u8} 1 [0x1]
+[23] = {u8} 4 [0x4]
+[24] = {u8} 1 [0x1]
+[25] = {u8} 5 [0x5]
+[26] = {u8} 1 [0x1]
+[27] = {u8} 6 [0x6]
+[28] = {u8} 14 [0xe]
+[29] = {u8} 14 [0xe]
+[30] = {u8} 7 [0x7]
+         */
+
+        final byte[] expectedBytes = {24, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 1, 1, 1, 2, 1, 3, 3, 0, 0, 0, 1, 4, 1, 5, 1, 6, 14, 14, 7};
+
+        List<CLValueU256> innerInernalList = new ArrayList<>();
+        innerInernalList.add(new CLValueU256(BigInteger.valueOf(1L)));
+        innerInernalList.add(new CLValueU256(BigInteger.valueOf(2L)));
+        innerInernalList.add(new CLValueU256(BigInteger.valueOf(3L)));
+        CLValueList innerList1 = new CLValueList(innerInernalList);
+
+        innerInernalList = new ArrayList<>();
+        innerInernalList.add(new CLValueU256(BigInteger.valueOf(4L)));
+        innerInernalList.add(new CLValueU256(BigInteger.valueOf(5L)));
+        innerInernalList.add(new CLValueU256(BigInteger.valueOf(6L)));
+        CLValueList innerList2 = new CLValueList(innerInernalList);
+
+        List<CLValueList> internalOutList = new ArrayList<>();
+        internalOutList.add(innerList1);
+        internalOutList.add(innerList2);
+        CLValueList outerList = new CLValueList(internalOutList);
+
+        final SerializerBuffer ser = new SerializerBuffer();
+        outerList.serialize(ser, Target.BYTE);
+
+        byte[] actualBytes = ser.toByteArray();
+        assertThat(actualBytes, is(expectedBytes));
+
+        CLValueList clValueList = (CLValueList) outerList.deserialize(new DeserializerBuffer(actualBytes), Target.BYTE);
+
+        assertThat(clValueList.getBytes(), is(outerList.getBytes()));
+
+    }
 }

--- a/src/test/java/com/casper/sdk/model/clvalue/CLValueTests.java
+++ b/src/test/java/com/casper/sdk/model/clvalue/CLValueTests.java
@@ -166,6 +166,9 @@ public class CLValueTests {
         final byte[] expected = {4, 0, 0, 0, 1, 0, 0, 0, 18, 18, 4};
 
         assertThat(ser.toByteArray(), is(expected));
+
+        final CLValueTuple1 deserialized = (CLValueTuple1) outerTuple1.deserialize(new DeserializerBuffer(expected), Target.BYTE);
+        assertThat(deserialized.getBytes(), is(outerTuple1.getBytes()));
     }
 
     @Test
@@ -291,40 +294,6 @@ public class CLValueTests {
     @Test
     void nestedListSerialization() throws Exception {
 
-        /*
-        [0] = {u8} 24 [0x18]
-[1] = {u8} 0 [0x0]
-[2] = {u8} 0 [0x0]
-[3] = {u8} 0 [0x0]
-[4] = {u8} 2 [0x2]
-[5] = {u8} 0 [0x0]
-[6] = {u8} 0 [0x0]
-[7] = {u8} 0 [0x0]
-[8] = {u8} 3 [0x3]
-[9] = {u8} 0 [0x0]
-[10] = {u8} 0 [0x0]
-[11] = {u8} 0 [0x0]
-[12] = {u8} 1 [0x1]
-[13] = {u8} 1 [0x1]
-[14] = {u8} 1 [0x1]
-[15] = {u8} 2 [0x2]
-[16] = {u8} 1 [0x1]
-[17] = {u8} 3 [0x3]
-[18] = {u8} 3 [0x3]
-[19] = {u8} 0 [0x0]
-[20] = {u8} 0 [0x0]
-[21] = {u8} 0 [0x0]
-[22] = {u8} 1 [0x1]
-[23] = {u8} 4 [0x4]
-[24] = {u8} 1 [0x1]
-[25] = {u8} 5 [0x5]
-[26] = {u8} 1 [0x1]
-[27] = {u8} 6 [0x6]
-[28] = {u8} 14 [0xe]
-[29] = {u8} 14 [0xe]
-[30] = {u8} 7 [0x7]
-         */
-
         final byte[] expectedBytes = {24, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 1, 1, 1, 2, 1, 3, 3, 0, 0, 0, 1, 4, 1, 5, 1, 6, 14, 14, 7};
 
         List<CLValueU256> innerInernalList = new ArrayList<>();
@@ -353,6 +322,5 @@ public class CLValueTests {
         CLValueList clValueList = (CLValueList) outerList.deserialize(new DeserializerBuffer(actualBytes), Target.BYTE);
 
         assertThat(clValueList.getBytes(), is(outerList.getBytes()));
-
     }
 }


### PR DESCRIPTION
CLTypes that contain child types were not correctly serializing. Refactored the AbstractCLType to be responsible for its own serialization, it was previously done by the AbstractCLValue, which resulted in this defect.